### PR TITLE
fix: optimistic lock handling

### DIFF
--- a/examples/user-account/src/user_account_repository.rs
+++ b/examples/user-account/src/user_account_repository.rs
@@ -59,7 +59,7 @@ impl UserAccountRepository {
 
   fn handle_event_store_write_error(err: EventStoreWriteError) -> RepositoryError {
     match err {
-      EventStoreWriteError::TransactionCanceledError(e) => RepositoryError::OptimisticLockError(e.to_string()),
+      EventStoreWriteError::OptimisticLockError(e) => RepositoryError::OptimisticLockError(e.to_string()),
       EventStoreWriteError::SerializationError(e) => RepositoryError::IOError(e.to_string()),
       EventStoreWriteError::IOError(e) => RepositoryError::IOError(e.to_string()),
       EventStoreWriteError::OtherError(e) => RepositoryError::IOError(e.to_string()),

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -8,8 +8,7 @@ use thiserror::Error;
 
 /// 集約のIDを表すトレイト。
 pub trait AggregateId:
-  std::fmt::Display + Debug + Clone + Serialize + for<'de> de::Deserialize<'de> + Send + Sync + 'static
-{
+  std::fmt::Display + Debug + Clone + Serialize + for<'de> de::Deserialize<'de> + Send + Sync + 'static {
   /// 集約の種別名を返す。
   fn type_name(&self) -> String;
   /// 集約のIDを文字列として返す

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -8,7 +8,8 @@ use thiserror::Error;
 
 /// 集約のIDを表すトレイト。
 pub trait AggregateId:
-  std::fmt::Display + Debug + Clone + Serialize + for<'de> de::Deserialize<'de> + Send + Sync + 'static {
+  std::fmt::Display + Debug + Clone + Serialize + for<'de> de::Deserialize<'de> + Send + Sync + 'static
+{
   /// 集約の種別名を返す。
   fn type_name(&self) -> String;
   /// 集約のIDを文字列として返す
@@ -62,15 +63,16 @@ pub trait EventStore: Debug + Clone + Sync + Send + 'static {
   /// - `Err(e)` - 保存に失敗した場合
   async fn persist_event(&mut self, event: &Self::EV, version: usize) -> Result<(), EventStoreWriteError>;
 
+  /// Saves an event and a snapshot.<br/>
   /// イベント及びスナップショットを保存します。
   ///
   /// # 引数
-  /// - `event` - 保存するイベント
-  /// - `aggregate` - スナップショットを保存する集約
+  /// - `event` - event to be saved / 保存するイベント
+  /// - `aggregate` - aggregate to be saved as a snapshot / スナップショットを保存する集約
   ///
   /// # 戻り値
-  /// - `Ok(())` - 保存に成功した場合
-  /// - `Err(e)` - 保存に失敗した場合
+  /// - `Ok(())` - if succeeded / 保存に成功した場合
+  /// - `Err(e)` - if failed / 保存に失敗した場合
   async fn persist_event_and_snapshot(
     &mut self,
     event: &Self::EV,
@@ -93,7 +95,7 @@ pub enum EventStoreWriteError {
   #[error("SerializeError: {0}")]
   SerializationError(Box<dyn StdError + Send + Sync>),
   #[error("TransactionCanceledError: {0}")]
-  TransactionCanceledError(#[from] TransactionCanceledException),
+  OptimisticLockError(#[from] TransactionCanceledException),
   #[error("IOError: {0}")]
   IOError(#[from] Box<dyn StdError + Send + Sync>),
   #[error("OtherError: {0}")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Improved error handling in `user_account_repository.rs`, `event_store.rs`, and `types.rs`. The code now provides more specific error information for `EventStoreWriteError::TransactionCanceledError`.
- Refactor: Renamed `TransactionCanceledError` variant of the `EventStoreWriteError` enum to `OptimisticLockError` for better semantics.
- Documentation: Updated comments and documentation for the `persist_event_and_snapshot` function in the `EventStore` trait with English translations.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->