### PR TITLE
v3: Replace the Event/Aggregate traits with the EventEnvelope API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: ci
 on:
   push:
-    branches: [ main ]
+    branches: [ main, feature/v3-event-envelope ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, feature/v3-event-envelope ]
   schedule:
     - cron: '0 0 * * *'
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: ci
 on:
   push:
-    branches: [ main, feature/v3-event-envelope ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, feature/v3-event-envelope ]
+    branches: [ main ]
   schedule:
     - cron: '0 0 * * *'
 env:
@@ -90,13 +90,37 @@ jobs:
           fi
   clippy:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # FR8.5 / NFR6.12: lint every backend, bigtable included. The examples are
+        # workspace members that enable the dynamodb / sqlite features of the library,
+        # so feature unification widens the effective feature set of each configuration;
+        # the per-feature isolation of the library graph stays with the feature-matrix job.
+        include:
+          - name: no-features
+            flags: --no-default-features
+          - name: dynamodb
+            flags: --no-default-features --features dynamodb
+          - name: bigtable
+            flags: --no-default-features --features bigtable
+          - name: sqlite
+            flags: --no-default-features --features sqlite
+          - name: sqlite-system
+            flags: --no-default-features --features sqlite-system
+            system-sqlite: true
+          - name: all-features
+            flags: --all-features
+    name: clippy (${{ matrix.name }})
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: clippy
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - if: matrix.system-sqlite
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
+      - run: cargo clippy --workspace --all-targets ${{ matrix.flags }} -- -D warnings
   audit:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-This release contains breaking changes and corresponds to the next **major** version.
+This release contains breaking changes and corresponds to the next **major** version
+(v3). See the migration guide in [docs/MIGRATION_GUIDE_v3.md](docs/MIGRATION_GUIDE_v3.md)
+(Japanese: [docs/MIGRATION_GUIDE_v3.ja.md](docs/MIGRATION_GUIDE_v3.ja.md)).
+
+### Changed
+
+- **BREAKING**: The `Event` / `Aggregate` traits were removed. Domain events and
+  aggregate state are now plain serde types (payloads); the store-facing metadata
+  travels in the new public envelope types `EventEnvelope<AID, P>` (aggregate_id /
+  seq_nr / occurred_at / manifest + payload) and `SnapshotEnvelope<A>` (payload +
+  seq_nr / version). `AggregateId` is unchanged.
+- **BREAKING**: The `EventStore` API now speaks envelopes with an explicit
+  `expected_version`: `persist_event(EventEnvelope, expected_version)`,
+  `persist_event_and_snapshot(EventEnvelope, aggregate, expected_version)`,
+  `get_latest_snapshot_by_id -> Option<SnapshotEnvelope<A>>`,
+  `get_events_by_id_since_seq_nr -> Vec<EventEnvelope<AID, P>>`. Creation is
+  `seq_nr == 1` with `expected_version == 0`; updates pass the version read from the
+  snapshot envelope. The store no longer writes the version back into the aggregate
+  (`set_version` is gone); the snapshot column/cell is authoritative.
+- **BREAKING**: Stored payloads are pure domain content. The library no longer
+  injects `seq_nr` / `version` metadata into the serialized JSON; the journal gained a
+  `manifest` column and `occurred_at` is stored with nanosecond precision (the
+  domain-supplied value round-trips exactly). See
+  [docs/DATABASE_SCHEMA.md](docs/DATABASE_SCHEMA.md) for the v3 layouts. **Rows
+  written by v2 are not readable by v3**, and no migration tooling is provided —
+  migrating stored data is the application's responsibility.
+- **BREAKING**: `with_keep_snapshot_count` now returns
+  `Result<Self, EventStoreWriteError>` and rejects `Some(0)` uniformly across all
+  backends (`None` disables retention).
+- **BREAKING**: The serializer SPI is payload-only (`EventSerializer<P>` /
+  `SnapshotSerializer<A>`; `deserialize` returns the payload directly).
+- An update addressed at an absent aggregate now uniformly returns
+  `OptimisticLockError` (message without `actual_version`) on every backend.
+- The Bigtable backend now performs its optimistic-lock check as a single-row
+  atomic CAS (`CheckAndMutateRow`) instead of a non-transactional
+  read→check→write sequence.
+
+### Added
+
+- `EventStoreWriteError::ContractViolation` — a dedicated variant for calls that
+  break the write contract (`seq_nr == 0`, creation/update mismatch,
+  `keep_snapshot_count == 0`), distinguishable from storage failures.
+- Snapshot retention for the Bigtable backend (`with_keep_snapshot_count` /
+  `with_delete_ttl`, history rows keyed by a zero-padded seq_nr suffix). Note that
+  which history rows survive pruning differs per backend: DynamoDB keeps the oldest,
+  Bigtable / SQLite keep the newest (documented in the schema document).
+- Migration guides: [docs/MIGRATION_GUIDE_v3.md](docs/MIGRATION_GUIDE_v3.md) and
+  [docs/MIGRATION_GUIDE_v3.ja.md](docs/MIGRATION_GUIDE_v3.ja.md).
+- A declared MSRV: `rust-version = "1.94.1"` in `lib/Cargo.toml`, measured with
+  `cargo build --all-features` (the AWS SDK stack currently requires 1.94.1).
+
+### Removed
+
+- The `Event` and `Aggregate` traits, `Aggregate::set_version`, and the metadata
+  injection into stored payloads.
+- The remaining `.unwrap()` on the DynamoDB `DeleteRequest` builder path (all
+  backend errors map to `EventStoreWriteError` / `EventStoreReadError`).
+
+### Internal
+
+- Optimistic-lock conflict and error-contract tests now cover DynamoDB and
+  Bigtable at the same depth as SQLite and the in-memory backend, and every
+  backend asserts at least one envelope-metadata round trip.
+- The clippy CI job runs a six-configuration feature matrix
+  (`--no-default-features`, each backend feature on its own, `--all-features`)
+  with `-D warnings`, so the Bigtable backend is linted too.
+- The examples were rewritten against the envelope API.
+
+## [2.0.0]
+
+This release contains breaking changes.
 See the migration guide in [README.md](README.md#migration-from-1x).
+(The automated release flow does not stamp this file; this section was retitled
+from "Unreleased" after v2.0.0 was published to crates.io.)
 
 ### Changed
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -38,52 +38,68 @@ event-store-adapter-rs = { version = "<latest>", features = ["sqlite"] }
 イベントストアを使えば、Event Sourcing対応リポジトリを簡単に実装できます。以下はSQLiteバックエンド（`features = ["sqlite"]`）を使う例です:
 
 ```rust
-use event_store_adapter_rs::types::{Aggregate, EventStore, EventStoreReadError, EventStoreWriteError};
+use event_store_adapter_rs::event_envelope::EventEnvelope;
+use event_store_adapter_rs::types::{EventStore, EventStoreReadError, EventStoreWriteError};
 use event_store_adapter_rs::EventStoreForSqlite;
 
+// UserAccount / UserAccountEvent はプレーンな `#[derive(Serialize, Deserialize)]` 型 —
+// v3 ではドメイン型にライブラリのtraitを実装する必要はありません。
 pub struct UserAccountRepository {
   event_store: EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent>,
 }
 
+/// 最新スナップショット + 差分リプレイから復元した読取結果。
+/// 次のイベントの採番は `seq_nr + 1`、次の書込のexpected_versionは `version` を使います。
+pub struct ReplayedUserAccount {
+  pub state: UserAccount,
+  pub seq_nr: usize,
+  pub version: usize,
+}
+
 impl UserAccountRepository {
-  pub async fn store_event(&mut self, event: &UserAccountEvent, version: usize) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event(event, version).await;
-    match result {
-      Ok(_) => Ok(()),
-      Err(err) => Err(Self::handle_event_store_write_error(err)),
-    }
+  pub async fn store_event(
+    &mut self,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    expected_version: usize,
+  ) -> Result<(), RepositoryError> {
+    self
+      .event_store
+      .persist_event(event, expected_version)
+      .await
+      .map_err(Self::handle_event_store_write_error)
   }
 
   pub async fn store_event_and_snapshot(
     &mut self,
-    event: &UserAccountEvent,
-    snapshot: &UserAccount,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    snapshot: UserAccount,
+    expected_version: usize,
   ) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event_and_snapshot(event, snapshot).await;
-    match result {
-      Ok(_) => Ok(()),
-      Err(err) => Err(Self::handle_event_store_write_error(err)),
-    }
+    self
+      .event_store
+      .persist_event_and_snapshot(event, snapshot, expected_version)
+      .await
+      .map_err(Self::handle_event_store_write_error)
   }
 
-  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<UserAccount>, RepositoryError> {
-    let snapshot_result = self.event_store.get_latest_snapshot_by_id(id).await;
-    match snapshot_result {
-      Ok(snapshot_opt) => match snapshot_opt {
-        Some(snapshot) => {
-          let events = self
-            .event_store
-            .get_events_by_id_since_seq_nr(id, snapshot.seq_nr() + 1)
-            .await;
-          match events {
-            Ok(events) => Ok(Some(UserAccount::replay(events, snapshot))),
-            Err(err) => Err(Self::handle_event_store_read_error(err)),
-          }
-        }
-        None => Ok(None),
-      },
-      Err(err) => Err(Self::handle_event_store_read_error(err)),
-    }
+  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<ReplayedUserAccount>, RepositoryError> {
+    let snapshot = match self.event_store.get_latest_snapshot_by_id(id).await {
+      Ok(Some(snapshot)) => snapshot,
+      Ok(None) => return Ok(None),
+      Err(err) => return Err(Self::handle_event_store_read_error(err)),
+    };
+    let (snapshot_seq_nr, version) = (snapshot.seq_nr(), snapshot.version());
+    let events = self
+      .event_store
+      .get_events_by_id_since_seq_nr(id, snapshot_seq_nr + 1)
+      .await
+      .map_err(Self::handle_event_store_read_error)?;
+    let seq_nr = events.last().map(|event| event.seq_nr()).unwrap_or(snapshot_seq_nr);
+    let state = UserAccount::replay(
+      events.into_iter().map(EventEnvelope::into_payload),
+      snapshot.into_aggregate(),
+    );
+    Ok(Some(ReplayedUserAccount { state, seq_nr, version }))
   }
 }
 ```
@@ -93,23 +109,22 @@ impl UserAccountRepository {
 ```rust
 // ファイルDB。`:memory:` を使う場合は EventStoreForSqlite::new_in_memory()
 let event_store = EventStoreForSqlite::new("user-account.db")?;
-
 let mut repository = UserAccountRepository::new(event_store);
 
-// Replay the aggregate from the event store
-let mut user_account = repository.find_by_id(&user_account_id).await?.unwrap();
+// 作成: ストリームの最初のイベントは seq_nr == 1 で、expected_version == 0 で書き込みます。
+let (user_account, created) = UserAccount::new(user_account_id.clone(), "test-1".to_string());
+let envelope = EventEnvelope::new(user_account_id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST);
+repository.store_event_and_snapshot(envelope, user_account, 0).await?;
 
-// Execute a command on the aggregate
-let user_account_event = user_account.rename("new-name").unwrap();
+// イベントストアから集約をリプレイ: seq_nr / version は集約フィールドではなく
+// 封筒（ストア側の列）から取得します。
+let mut replayed = repository.find_by_id(&user_account_id).await?.unwrap();
 
-// Store the new event without a snapshot
-repository
-  .store_event(&user_account_event, user_account.version())
-  .await?;
-// Store the new event with a snapshot
-// repository
-//   .store_event_and_snapshot(&user_account_event, &user_account)
-//   .await?;
+// コマンドを実行し、次のイベントを replayed.seq_nr + 1 で採番、リプレイした
+// version を楽観的ロックの expected_version として渡します。
+let renamed = replayed.state.rename("new-name").unwrap();
+let envelope = EventEnvelope::new(user_account_id.clone(), replayed.seq_nr + 1, Utc::now(), renamed);
+repository.store_event(envelope, replayed.version).await?;
 ```
 
 実行可能な完全なサンプルは [examples/user-account-sqlite](examples/user-account-sqlite) です（`cargo run -p example-user-account-sqlite` — クラウド接続・Docker不要）。
@@ -133,6 +148,10 @@ let event_store = EventStoreForDynamoDB::new(
 
 - サポートされる共有単位は**1つのストアインスタンスとそのクローン**です（クローンは基底の接続を共有します）。同一のデータベースファイルを複数のストアインスタンスや複数プロセスから同時に開くことは**サポート外**です。マルチプロセスでの同時アクセスの防止（例: CLIツールの多重起動防止）はアプリケーション側の責務です。
 - インメモリストア（`new_in_memory`）はそのインスタンスとクローンの間でのみ共有され、最後のクローンがdropされた時点で消えます。
+
+## 3.x への移行
+
+3.x では `Event` / `Aggregate` traitが `EventEnvelope` APIに置き換わります: ドメインのイベント型・集約型はプレーンな `serde` 型となり、メタデータ（`aggregate_id` / `seq_nr` / `occurred_at` / `manifest`）は封筒が運搬し、楽観的ロックのversionはストア側の列のみが保持します。**2.x で書き込まれたデータは 3.x では読み取れません** — 保存済みデータの移行は利用者の責務です。完全なガイドは [docs/MIGRATION_GUIDE_v3.ja.md](docs/MIGRATION_GUIDE_v3.ja.md)（[English](docs/MIGRATION_GUIDE_v3.md)）を参照してください。
 
 ## 1.x からの移行
 

--- a/README.md
+++ b/README.md
@@ -38,52 +38,68 @@ Notes:
 You can easily implement an Event Sourcing-enabled repository using an event store. The following uses the SQLite backend (`features = ["sqlite"]`):
 
 ```rust
-use event_store_adapter_rs::types::{Aggregate, EventStore, EventStoreReadError, EventStoreWriteError};
+use event_store_adapter_rs::event_envelope::EventEnvelope;
+use event_store_adapter_rs::types::{EventStore, EventStoreReadError, EventStoreWriteError};
 use event_store_adapter_rs::EventStoreForSqlite;
 
+// UserAccount / UserAccountEvent are plain `#[derive(Serialize, Deserialize)]` types —
+// v3 requires no library traits on your domain types.
 pub struct UserAccountRepository {
   event_store: EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent>,
 }
 
+/// Read result restored from the latest snapshot plus the differential replay.
+/// `seq_nr` numbers the next event as `seq_nr + 1`; `version` is the expected_version for the next write.
+pub struct ReplayedUserAccount {
+  pub state: UserAccount,
+  pub seq_nr: usize,
+  pub version: usize,
+}
+
 impl UserAccountRepository {
-  pub async fn store_event(&mut self, event: &UserAccountEvent, version: usize) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event(event, version).await;
-    match result {
-      Ok(_) => Ok(()),
-      Err(err) => Err(Self::handle_event_store_write_error(err)),
-    }
+  pub async fn store_event(
+    &mut self,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    expected_version: usize,
+  ) -> Result<(), RepositoryError> {
+    self
+      .event_store
+      .persist_event(event, expected_version)
+      .await
+      .map_err(Self::handle_event_store_write_error)
   }
 
   pub async fn store_event_and_snapshot(
     &mut self,
-    event: &UserAccountEvent,
-    snapshot: &UserAccount,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    snapshot: UserAccount,
+    expected_version: usize,
   ) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event_and_snapshot(event, snapshot).await;
-    match result {
-      Ok(_) => Ok(()),
-      Err(err) => Err(Self::handle_event_store_write_error(err)),
-    }
+    self
+      .event_store
+      .persist_event_and_snapshot(event, snapshot, expected_version)
+      .await
+      .map_err(Self::handle_event_store_write_error)
   }
 
-  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<UserAccount>, RepositoryError> {
-    let snapshot_result = self.event_store.get_latest_snapshot_by_id(id).await;
-    match snapshot_result {
-      Ok(snapshot_opt) => match snapshot_opt {
-        Some(snapshot) => {
-          let events = self
-            .event_store
-            .get_events_by_id_since_seq_nr(id, snapshot.seq_nr() + 1)
-            .await;
-          match events {
-            Ok(events) => Ok(Some(UserAccount::replay(events, snapshot))),
-            Err(err) => Err(Self::handle_event_store_read_error(err)),
-          }
-        }
-        None => Ok(None),
-      },
-      Err(err) => Err(Self::handle_event_store_read_error(err)),
-    }
+  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<ReplayedUserAccount>, RepositoryError> {
+    let snapshot = match self.event_store.get_latest_snapshot_by_id(id).await {
+      Ok(Some(snapshot)) => snapshot,
+      Ok(None) => return Ok(None),
+      Err(err) => return Err(Self::handle_event_store_read_error(err)),
+    };
+    let (snapshot_seq_nr, version) = (snapshot.seq_nr(), snapshot.version());
+    let events = self
+      .event_store
+      .get_events_by_id_since_seq_nr(id, snapshot_seq_nr + 1)
+      .await
+      .map_err(Self::handle_event_store_read_error)?;
+    let seq_nr = events.last().map(|event| event.seq_nr()).unwrap_or(snapshot_seq_nr);
+    let state = UserAccount::replay(
+      events.into_iter().map(EventEnvelope::into_payload),
+      snapshot.into_aggregate(),
+    );
+    Ok(Some(ReplayedUserAccount { state, seq_nr, version }))
   }
 }
 ```
@@ -93,23 +109,22 @@ The following is an example of the repository usage with SQLite. The store persi
 ```rust
 // A file-backed database. Use EventStoreForSqlite::new_in_memory() for `:memory:`.
 let event_store = EventStoreForSqlite::new("user-account.db")?;
-
 let mut repository = UserAccountRepository::new(event_store);
 
-// Replay the aggregate from the event store
-let mut user_account = repository.find_by_id(&user_account_id).await?.unwrap();
+// Create: the first event of a stream is seq_nr == 1 and is written with expected_version == 0.
+let (user_account, created) = UserAccount::new(user_account_id.clone(), "test-1".to_string());
+let envelope = EventEnvelope::new(user_account_id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST);
+repository.store_event_and_snapshot(envelope, user_account, 0).await?;
 
-// Execute a command on the aggregate
-let user_account_event = user_account.rename("new-name").unwrap();
+// Replay the aggregate from the event store: seq_nr / version come from the
+// envelopes (the store columns), not from aggregate fields.
+let mut replayed = repository.find_by_id(&user_account_id).await?.unwrap();
 
-// Store the new event without a snapshot
-repository
-  .store_event(&user_account_event, user_account.version())
-  .await?;
-// Store the new event with a snapshot
-// repository
-//   .store_event_and_snapshot(&user_account_event, &user_account)
-//   .await?;
+// Execute a command, number the next event as replayed.seq_nr + 1, and pass the
+// replayed version as expected_version for the optimistic lock.
+let renamed = replayed.state.rename("new-name").unwrap();
+let envelope = EventEnvelope::new(user_account_id.clone(), replayed.seq_nr + 1, Utc::now(), renamed);
+repository.store_event(envelope, replayed.version).await?;
 ```
 
 A complete runnable example is [examples/user-account-sqlite](examples/user-account-sqlite) (`cargo run -p example-user-account-sqlite` — no cloud connection, no Docker).
@@ -133,6 +148,10 @@ A complete runnable DynamoDB example is [examples/user-account](examples/user-ac
 
 - The supported sharing unit is **one store instance and its clones** (clones share the underlying connection). Opening the same database file from multiple store instances or from multiple processes is **not supported**. Guarding against concurrent multi-process access (for example, preventing multiple instances of a CLI tool from running at once) is the application's responsibility.
 - An in-memory store (`new_in_memory`) is shared by the instance and its clones only, and disappears when the last clone is dropped.
+
+## Migration to 3.x
+
+The 3.x line replaces the `Event` / `Aggregate` traits with the `EventEnvelope` API: domain event and aggregate types are plain `serde` types, metadata (`aggregate_id` / `seq_nr` / `occurred_at` / `manifest`) travels in the envelope, and the optimistic-lock version lives in the store columns only. **Data written by 2.x cannot be read by 3.x** — migrating stored data is the user's responsibility. See [docs/MIGRATION_GUIDE_v3.md](docs/MIGRATION_GUIDE_v3.md) ([日本語](docs/MIGRATION_GUIDE_v3.ja.md)) for the complete guide.
 
 ## Migration from 1.x
 

--- a/docs/DATABASE_SCHEMA.ja.md
+++ b/docs/DATABASE_SCHEMA.ja.md
@@ -1,61 +1,153 @@
-## EventStoreが利用するDynamoDBのテーブル構成
+# 各イベントストアが利用するデータベーススキーマ（v3）
+
+**本ドキュメントは情報提供です。** v3 の封筒型（`EventEnvelope` / `SnapshotEnvelope`）を
+各バックエンドがどのような物理レイアウトで保存するかを説明します。封筒メタデータ
+（イベントは `aggregate_id` / `seq_nr` / `occurred_at` / `manifest`、スナップショットは
+`seq_nr` / `version`）は専用の列・属性・セルに保存され、payload 列は**純粋なドメイン内容
+のみ**を保持します — ライブラリが直列化 payload へ `version` / `seq_nr` / タイムスタンプを
+注入することはなくなりました。
+
+> v3 のレイアウトは v2 から変更されています（journal への `manifest` 列の追加、
+> `occurred_at` のナノ秒精度化、snapshot payload からのメタデータ注入の廃止、
+> current/履歴判別のキーへの移動）。v2 で書き込まれた行の読み取りはサポートしません。
+> 移行方針は [MIGRATION_GUIDE_v3.ja.md](MIGRATION_GUIDE_v3.ja.md) を参照してください。
+
+### スナップショット保持のバックエンド間非対称
+
+`with_keep_snapshot_count(Some(n))` を有効にすると、どのバックエンドも履歴スナップ
+ショットの**件数**を `n` に抑えますが、**どの行が残るか**は異なります。
+
+- **DynamoDB** は超過分を**新しい側**の履歴から剪定します（seq_nr 降順クエリ）。
+  そのため**旧い側**の履歴が残ります。
+- **Bigtable / SQLite** は**新しい順に `n` 件**の履歴を残し、旧い側の超過分を削除します。
+
+件数の意味論は同一で、残存選択のみが非対称です（各バックエンドの v3 以前の挙動を
+そのまま維持したものです）。
+
+## EventStore が利用する DynamoDB のテーブル構成
 
 - Journal
 - Snapshot
 
-いずれのテーブルも、キー設計の前提としては、論理シャード内で最大限に書き込みが分散させることを想定しています。
+いずれのテーブルも、キー設計の前提として、論理シャード内で最大限に書き込みが分散することを想定しています。テーブル作成はライブラリの責務外です（参考定義は `test-utils` を参照）。
 
-### Journalテーブル
+### Journal テーブル
 
-集約で起きたイベントを保存するためのテーブル。原則的に、このイベントを使って集約状態を再生(リプレイ)します。
+集約で起きたイベントを保存するためのテーブル。原則的に、このイベントを使って集約状態を再生（リプレイ）します。`EventEnvelope` 1 つが 1 項目に対応します。
 
-| キー名         | 説明                                    | 具体的な値                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 備考 |
-|:------------|:--------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---|
-| pkey        | パーションキー(集約種別名-hash(集約ID) % 論理シャードサイズ) | user-account-1                                                                                                                                                                                                                                                                                                                                                                                                                                                       |    |
-| skey        | ソートキー(集約種別名-集約IDの値部分-シーケンス番号)         | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-12345                                                                                                                                                                                                                                                                                                                                                                                                                        |    |
-| aid         | 集約ID                                  | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z                                                                                                                                                                                                                                                                                                                                                                                                                              |    |
-| ser_nr      | シーケンス番号(開始番号は1)                       | 12345                                                                                                                                                                                                                                                                                                                                                                                                                                                              |    |
-| payload     | イベント内容                                | {"type":"Created","id":"01H42KBHCW1BZG504J4ZXKA2F2","aggregate_id":{"value":"01890535-c59c-72d5-08a8-dcea316374c8"},"seq_nr":1,"name":"test","members":{"members_ids_by_user_account_id":{"01H42KBHCWBDTZYQ7P78T8BTWX":"01H42KBHCWA8NE32M49YH544H1"},"members":{"01H42KBHCWA8NE32M49YH544H1":{"id":"01H42KBHCWA8NE32M49YH544H1","user_account_id":{"value":"01890535-c59c-5b75-ff5c-f63a3485eb9d"},"role":"Admin"}}},"occurred_at":"2023-06-29T03:32:37.404481Z"} |    |
-| occurred_at | 発生日時                                  | 2023-06-29T03:32:37.404481Z                                                                                                                                                                                                                                                                                                                                                                                                                                        |    |
+| 属性名 | 型 | 説明 | 具体的な値 |
+|:------------|:----|:--------------------------------------|:---|
+| pkey        | S | パーティションキー（`集約種別名-hash(集約ID) % 論理シャードサイズ`） | `user-account-1` |
+| skey        | S | ソートキー（`集約種別名-集約IDの値部分-シーケンス番号`） | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-12345` |
+| aid         | S | 集約 ID | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z` |
+| seq_nr      | N | シーケンス番号（開始番号は 1、採番はドメイン側の責務） | `12345` |
+| payload     | B | イベント payload — 純粋なドメイン内容のみ（既定は JSON 直列化） | `{"Created":{"name":"test"}}` |
+| occurred_at | N | イベント発生日時（Unix epoch **ナノ秒**。ドメイン供給値が完全往復する） | `1688009557404481000` |
+| manifest    | S | 利用者供給・自由形式の型判別子（省略時は空文字列） | `user-account-created/v1` |
 
-aidとseq_nrはGSIが適用されており、リプレイ時はこのインデックスを利用されます。
+`(aid, seq_nr)` に GSI が適用されており、リプレイ時にこのインデックスを利用します。
 
-### Snapshotテーブル
+### Snapshot テーブル
 
-集約の状態を保存するためのテーブルであり、集約のリプレイを高速化するためのテーブルです。スナップショット保存後にもイベントは保存されるため、最新の集約状態を表さない場合あります。
+集約の状態を保存するためのテーブルであり、集約のリプレイを高速化するためのテーブルです。スナップショット保存後にもイベントは保存されるため、最新の集約状態を表さない場合があります。
 
-| キー名     | 説明                                                               | 具体的な値                                                                                                                                                                                                                                                                                                                                                                                      | 備考 |
-|:--------|:-----------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---|
-| pkey    | パーションキー(集約種別名-hash(集約ID) % 論理シャードサイズ)                            | user-account-1                                                                                                                                                                                                                                                                                                                                                                               |    |
-| skey    | ソートキー(集約種別名-集約IDの値部分-シーケンス番号), 最新のスナップショットはシーケンス番号=0として読み書きされます。 | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-12345                                                                                                                                                                                                                                                                                                                                                |    |
-| payload | 集約の状態                                                            | {"id":{"value":"0189053a-d0b4-8f9b-4fb6-db91f72ccf16"},"name":"test","members":{"members_ids_by_user_account_id":{"01H42KNM5MBVRBZTADAZ9ETSPZ":"01H42KNM5M2QEW700VCW4J2KYE"},"members":{"01H42KNM5M2QEW700VCW4J2KYE":{"id":"01H42KNM5M2QEW700VCW4J2KYE","user_account_id":{"value":"0189053a-d0b4-5ef0-bfe9-4d57d2ed66df"},"role":"Admin"}}},"messages":[],"seq_nr_counter":1,"version":1} |    |
-| aid     | 集約ID                                                             | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z                                                                                                                                                                                                                                                                                                                                                      |    |
-| ser_nr  | シーケンス番号(開始番号は1)                                                  | 12345                                                                                                                                                                                                                                                                                                                                                                                      |    |
-| ttl     | 削除のためのTTL(秒)                                                     | 1624980000                                                                                                                                                                                                                                                                                                                                                                                 |    |
-| version | バージョン(楽観的ロック用)(開始番号は1)                                           | 1                                                                                                                                                                                                                                                                                                                                                                                          |    |
+| 属性名 | 型 | 説明 | 具体的な値 |
+|:--------|:----|:-----------------------------------------------------------------|:---|
+| pkey    | S | パーティションキー（`集約種別名-hash(集約ID) % 論理シャードサイズ`） | `user-account-1` |
+| skey    | S | ソートキー（`集約種別名-集約IDの値部分-シーケンス番号`）。current スナップショットは**マーカー `0`** で整形した skey のスロットに置かれ、履歴項目はイベントの seq_nr を使う | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-0` |
+| aid     | S | 集約 ID | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z` |
+| seq_nr  | N | スナップショットが反映済みのシーケンス番号。**v2 と異なり current 項目にも実値が入る**（マーカー `0` は skey の中にのみ現れる） | `12345` |
+| version | N | 楽観的ロックの版数（開始番号は 1）。列値が正であり、payload から補正されることはない | `1` |
+| payload | B | 集約の状態 — 純粋なドメイン内容のみ（既定は JSON 直列化。`version` / `seq_nr` の注入なし） | `{"id":{"value":"..."},"name":"test"}` |
+| ttl     | N | 削除用 TTL（epoch 秒。`0` = 無期限。`with_delete_ttl` 設定時に超過履歴項目へ将来時刻が設定される） | `1624980000` |
+| last_updated_at | N | 最終更新日時（Unix epoch ミリ秒。イベントの `occurred_at` から導出） | `1688009557404` |
 
-- スナップショット冗長化機能が無効な場合はskey=0にスナップショットが保存されるだけですが、有効にした場合はスナップショットはskey=0以外にskey=aggregate.seq_nr()の2件保存されます。スナップショットを保存するたびにskey=aggregate.seq_nr()のスナップショットが増えますが、あなたはスナップショットは上限を指定できます(デフォルトは1)。上限を超えた場合は古いスナップショットから削除されます。デフォルトでは、クライアント主導で削除されます。TTLを使ってDynamoDB自身に削除させることもできます。
-- aidとseq_nrはGSIが適用されており、リプレイ時はこのインデックスを利用されます。
+- current スナップショットは主キー（`pkey` + マーカー `0` の skey）への強整合
+  `GetItem` で読み取ります。その `version` を次回書込の `expected_version` として
+  渡します。
+- 履歴項目（skey = イベントの seq_nr）は **`with_keep_snapshot_count(Some(n))` が有効な
+  ときのみ**、current 項目・journal 項目と同一トランザクションで書き込まれます。
+- `(aid, seq_nr)` の GSI は保持ポリシーのクエリに使われます。`n` 件を超える履歴は
+  削除されるか、`with_delete_ttl` 設定時は将来の `ttl` 値が設定され DynamoDB 側で
+  期限切れ削除されます（上記の非対称の注記どおり、剪定対象は新しい側から選ばれます）。
 
-### イベント及びスナップショットの書き込み
+### イベントとスナップショットの書き込み
 
-1. 集約にてコマンドが受理されると、最新のseq_nrが付与されたイベントが生成されます。
-2. 生成されたイベントはjournalテーブルに書き込まれます。ただし、この書き込みは必ずsnapshotテーブルと同じトランザクションで行われ、versionが一致する条件下で実施されます。初回のイベント以外は、snapshotのpayloadを更新することはオプションです。
+1. コマンドが集約に受理されると、ドメインが次のイベントを生成し、ドメイン採番の
+   `seq_nr`（開始番号 1）を持つ `EventEnvelope` に包みます。
+2. journal への Put とスナップショットの書き込みは常に単一の `TransactWriteItems` で
+   実行されます。ストリーム最初のイベント（seq_nr=1、expected_version=0）は
+   `attribute_not_exists` 条件で両項目を作成し、以降の書き込みは
+   `version = expected_version` 条件で current スナップショット項目を更新して
+   `version = expected_version + 1` を設定します。条件不成立は `OptimisticLockError`
+   になります。
 
-### イベント及びスナップショットを使って集約をリプレイする
+### イベントとスナップショットによる集約のリプレイ
 
-1. 集約のIDを指定して、スナップショットを取得します。
-2. 取得した集約のIDとスナップショットのシーケンス番号以降のイベントをjournalテーブルから読み込みます。
-3. 読み込んだイベントをスナップショットに適用することで、最新の集約状態を取得します。
+1. 集約 ID を指定して最新の `SnapshotEnvelope` を取得します。
+2. journal テーブルから封筒の `seq_nr` より後のイベントを読み取ります。
+3. 読み取ったイベントをスナップショット状態に適用して最新の集約状態を得ます。
+   次回書込では封筒の `version` を `expected_version` として渡します。
 
-## EventStoreForSqliteが利用するSQLiteのテーブル構成
+## EventStoreForBigtable が利用する Bigtable のテーブル構成
+
+- journal テーブル — カラムファミリ `event`
+- snapshot テーブル — カラムファミリ `snapshot`
+
+すべての値はバイト列として保存され、数値セルは 10 進文字列を保持します。読取と CAS 述語は
+cells-per-column limit 1 を使うため、各カラムの最新セルが正です。
+
+### journal テーブル（Bigtable）
+
+行キー: `${パーティションキー}#${集約種別名}#${集約IDの値部分}#${seq_nr の 20 桁ゼロ詰め}`
+（パーティションキーは `集約種別名-hash(集約ID) % シャード数`）。`EventEnvelope` 1 つが 1 行に対応します。
+
+| カラム（ファミリ `event`） | 説明 | 具体的な値 |
+|:------------|:--------------------------------------|:---|
+| payload     | イベント payload — 純粋なドメイン内容のみ（既定は JSON 直列化） | `{"Created":{"name":"test"}}` |
+| aggregate_id | 集約 ID の値部分 | `01H42K4ABWQ5V2XQEP3A48VE0Z` |
+| seq_nr      | シーケンス番号（開始番号は 1、採番はドメイン側の責務） | `12345` |
+| occurred_at | イベント発生日時（**ナノ秒**精度の RFC 3339 文字列。ドメイン供給値が完全往復する） | `2023-06-29T03:32:37.404481000Z` |
+| manifest    | 利用者供給・自由形式の型判別子（省略時は空文字列） | `user-account-created/v1` |
+
+seq_nr のゼロ詰めにより同一集約の行キーが連続・整列するため、リプレイは接頭辞の
+範囲走査で行われます。
+
+### snapshot テーブル（Bigtable）
+
+current 行キー: `${パーティションキー}#${集約種別名}#${集約IDの値部分}`。
+履歴行キー: current 行キー + `#` + seq_nr のゼロ詰め（キー昇順 = 旧い順）。
+
+| カラム（ファミリ `snapshot`） | 説明 | 具体的な値 |
+|:------------|:--------------------------------------|:---|
+| payload     | 集約の状態 — 純粋なドメイン内容のみ（`version` / `seq_nr` の注入なし） | `{"id":{"value":"..."},"name":"test"}` |
+| seq_nr      | スナップショットが反映済みのシーケンス番号 | `12345` |
+| version     | 楽観的ロックの版数（開始番号は 1）。セル値が正 | `1` |
+| last_updated_at | 最終更新日時（Unix epoch ミリ秒） | `1688009557404` |
+
+- 書き込みは `CheckAndMutateRow`（単一行原子性 CAS）を通ります。新規作成は `version`
+  セルの不在を、更新は `version == expected_version` のバイト完全一致を述語で検査し、
+  `version = expected_version + 1` を設定します。述語不成立は `OptimisticLockError`
+  になります。
+- 履歴行は **`with_keep_snapshot_count(Some(n))` が有効なときのみ**書き込まれます。
+  CAS 勝者が current 行のプレイメージを別呼び出しのベストエフォート書込で履歴行キーへ
+  コピーします。
+- 保持ポリシーは新しい順に `n` 件の履歴行を残し、旧い側の超過分を `DeleteFromRow` で
+  削除します。`with_delete_ttl` を併用すると、`last_updated_at` が TTL より古い履歴行も
+  削除されます。
+
+## EventStoreForSqlite が利用する SQLite のテーブル構成
 
 - journal
 - snapshot
 
-**この節は情報提供です。** テーブルとインデックスはストアの構築時にライブラリが自動作成します（冪等な `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`）。利用者がこのDDLを実行する必要はありません。
+テーブルとインデックスはストア構築時にライブラリが自動作成します（冪等な
+`CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`）。利用者による DDL は
+不要であり、想定していません。
 
-キー設計はDynamoDBのテーブルと対応しています。`pkey` / `skey` が書き込みアドレス（`PRIMARY KEY (pkey, skey)`）となり論理シャードへ書き込みを分散し、`(aid, seq_nr)` が集約のリプレイに使う読み込みキーです。
+キー設計は DynamoDB テーブルを踏襲しています。`pkey` / `skey` が書き込みアドレス
+（`PRIMARY KEY (pkey, skey)`）となって論理シャードへ書き込みを分散し、`(aid, seq_nr)`
+がリプレイに使う読み取りキーです。
 
 ```sql
 CREATE TABLE IF NOT EXISTS journal (
@@ -65,6 +157,7 @@ CREATE TABLE IF NOT EXISTS journal (
   seq_nr INTEGER NOT NULL,
   payload BLOB NOT NULL,
   occurred_at INTEGER NOT NULL,
+  manifest TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (pkey, skey)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS journal_aid_seq_nr_idx ON journal (aid, seq_nr);
@@ -81,32 +174,40 @@ CREATE TABLE IF NOT EXISTS snapshot (
 CREATE INDEX IF NOT EXISTS snapshot_aid_seq_nr_idx ON snapshot (aid, seq_nr);
 ```
 
-### journalテーブル（SQLite）
+### journal テーブル（SQLite）
 
 | 列名 | 型 | 説明 |
-|:-----|:---|:-----|
-| pkey | TEXT | パーティションキー（集約種別名-hash(集約ID) % シャード数）— 書き込み分散キー。主キーの一部 |
-| skey | TEXT | ソートキー（集約種別名-集約IDの値部分-シーケンス番号）— 主キーの一部 |
-| aid | TEXT | 集約ID |
-| seq_nr | INTEGER | シーケンス番号（開始番号は1） |
-| payload | BLOB | イベント内容（デフォルトではJSONシリアライズ） |
-| occurred_at | INTEGER | イベントの発生日時（Unixエポックミリ秒） |
+|:------------|:-----|:------------|
+| pkey | TEXT | パーティションキー（`集約種別名-hash(集約ID) % シャード数`）— 書き込み分散キー。主キーの一部 |
+| skey | TEXT | ソートキー（`集約種別名-集約IDの値部分-シーケンス番号`）— 主キーの一部 |
+| aid | TEXT | 集約 ID |
+| seq_nr | INTEGER | シーケンス番号（開始番号は 1、採番はドメイン側の責務） |
+| payload | BLOB | イベント payload — 純粋なドメイン内容のみ（既定は JSON 直列化） |
+| occurred_at | INTEGER | イベント発生日時（Unix epoch **ナノ秒**。ドメイン供給値が完全往復する。範囲外の値は書込時に拒否） |
+| manifest | TEXT | 利用者供給・自由形式の型判別子（省略時は空文字列） |
 
-`(aid, seq_nr)` のユニークインデックスがDynamoDBのGSIに相当し、リプレイ時に利用されます。
+`(aid, seq_nr)` のユニークインデックスが DynamoDB の GSI に相当し、リプレイ時に利用されます。
 
-### snapshotテーブル（SQLite）
+### snapshot テーブル（SQLite）
 
 | 列名 | 型 | 説明 |
-|:-----|:---|:-----|
-| pkey | TEXT | パーティションキー（集約種別名-hash(集約ID) % シャード数）— 書き込み分散キー。主キーの一部 |
-| skey | TEXT | ソートキー（集約種別名-集約IDの値部分-シーケンス番号）。最新のスナップショットはシーケンス番号=0として読み書きされます |
-| aid | TEXT | 集約ID |
-| seq_nr | INTEGER | シーケンス番号（現行スロット行は0を維持し、履歴行は集約のseq_nrを持ちます） |
-| version | INTEGER | バージョン（楽観的ロック用。開始番号は1） |
-| payload | BLOB | 集約の状態（デフォルトではJSONシリアライズ） |
-| last_updated_at | INTEGER | 最終更新日時（Unixエポックミリ秒）。スナップショット保持TTLの判定にも使用 |
+|:------------|:-----|:------------|
+| pkey | TEXT | パーティションキー（`集約種別名-hash(集約ID) % シャード数`）— 書き込み分散キー。主キーの一部 |
+| skey | TEXT | ソートキー（`集約種別名-集約IDの値部分-シーケンス番号`）。current スナップショットは**マーカー `0`** で整形した skey のスロットに置かれ、履歴行はイベントの seq_nr を使う |
+| aid | TEXT | 集約 ID |
+| seq_nr | INTEGER | スナップショットが反映済みのシーケンス番号。**v2 と異なり current 行にも実値が入る**（マーカー `0` は skey の中にのみ現れ、current/履歴の判別はこの列ではなく skey で行う） |
+| version | INTEGER | 楽観的ロックの版数（開始番号は 1）。列値が正であり、payload から補正されることはない |
+| payload | BLOB | 集約の状態 — 純粋なドメイン内容のみ（既定は JSON 直列化。`version` / `seq_nr` の注入なし） |
+| last_updated_at | INTEGER | 最終更新日時（Unix epoch ミリ秒）。スナップショット保持 TTL の評価にも使用 |
 
 `(aid, seq_nr)` のインデックスがリプレイ時に利用されます。
 
-- 楽観的ロックの検証と書き込みは単一のSQLiteトランザクション内で行われます。journalへの挿入とsnapshotの条件付き更新（`WHERE version = expected`）は、まとめてコミットまたはまとめてロールバックされます。バージョン不一致は `OptimisticLockError` として返されます。
-- スナップショット保持は `with_keep_snapshot_count` で有効になり、seq_nr=0のスロットに加えて履歴スナップショット行（seq_nr > 0）が挿入され、上限超過・期限切れの履歴行は各永続化の後にクライアント主導で削除されます。`with_delete_ttl` は保持数が設定されている場合にのみ効果を持ちます（DynamoDBバックエンドと対称の契約 — 単独設定では履歴が記録されません）。DynamoDBと異なりストレージ側のTTL機構はないため、削除は常にライブラリが行います。
+- 楽観的ロックの検証と書き込みは単一の SQLite トランザクション内で行われます。
+  journal への INSERT と条件付きスナップショット UPDATE（`WHERE version = expected`）は
+  一緒にコミットされるか一緒にロールバックされます。ストリーム最初のイベント
+  （seq_nr=1、expected_version=0）は両行を INSERT し、この経路での主キー／ユニーク
+  インデックス衝突は `expected_version=0` の `OptimisticLockError` になります。
+- 履歴行は **`with_keep_snapshot_count(Some(n))` が有効なときのみ**同一トランザク
+  ションで INSERT されます。保持ポリシーは新しい順に `n` 件の履歴行を残し、旧い側の
+  超過分を削除します（`ORDER BY seq_nr ASC LIMIT excess`）。`with_delete_ttl` を併用
+  すると、`last_updated_at` が TTL より古い履歴行も削除されます。

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,61 +1,153 @@
+# Database schemas used by the event stores (v3)
+
+**This document is informational.** It describes how each backend lays out the v3
+envelope types (`EventEnvelope` / `SnapshotEnvelope`) physically. The envelope metadata
+(`aggregate_id` / `seq_nr` / `occurred_at` / `manifest` for events, `seq_nr` / `version`
+for snapshots) is stored in dedicated columns/attributes/cells, and the payload
+column holds **pure domain content only** — the library no longer injects `version`,
+`seq_nr`, or timestamps into the serialized payload.
+
+> The v3 layout differs from the v2 layout (the journal gained a `manifest`
+> column, `occurred_at` became nanosecond-precision, the snapshot payload lost the
+> injected metadata, and the current/history discrimination moved to the key). Reading
+> rows written by v2 is not supported; see
+> [MIGRATION_GUIDE_v3.md](MIGRATION_GUIDE_v3.md) for the migration stance.
+
+### Snapshot-retention asymmetry across backends
+
+When `with_keep_snapshot_count(Some(n))` is enabled, every backend bounds the
+*number* of history snapshots to `n`, but **which** rows survive differs:
+
+- **DynamoDB** prunes the excess from the **newest** history items (descending
+  `seq_nr` query), so the **oldest** history items remain.
+- **Bigtable / SQLite** keep the **newest `n`** history rows and delete the oldest
+  excess.
+
+The count semantics are identical; only the residual selection is asymmetric
+(kept as-is from the pre-v3 behavior of each backend).
+
 ## DynamoDB table schema used by EventStore
 
 - Journal
 - Snapshot
 
-The key design assumption for both tables is that writes are distributed to the greatest extent possible within the logical shard.
+The key design assumption for both tables is that writes are distributed to the greatest extent possible within the logical shard. Table creation stays outside the library (see `test-utils` for a reference definition).
 
 ### Journal table
 
-The table used to store events that have occurred in an aggregate. In principle, this event is used to replay (replay) the aggregate state.
+The table used to store events that have occurred in an aggregate. In principle, this event is used to replay the aggregate state. One `EventEnvelope` maps to one item.
 
-| key name    | description                                                          | example                                                                                                                                                                                                                                                                                                                                                                                                                                                            | remarks |
-|:------------|:---------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|
-| pkey        | Partition key(${aggregate-type-name}-hash($aid) % logical-shard-size) | user-account-1                                                                                                                                                                                                                                                                                                                                                                                                                                                       |         |
-| skey        | Sort Key(${aggregate type name}-${aid.value}-${seq_nr})              | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-12345                                                                                                                                                                                                                                                                                                                                                                                                                        |         |
-| aid         | Aggregate ID                                                         | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z                                                                                                                                                                                                                                                                                                                                                                                                                              |         |
-| ser_nr      | Sequence Number(origin=1)                                                      | 12345                                                                                                                                                                                                                                                                                                                                                                                                                                                              |         |
-| payload     | Event Payload                                                        | {"type":"Created","id":"01H42KBHCW1BZG504J4ZXKA2F2","aggregate_id":{"value":"01890535-c59c-72d5-08a8-dcea316374c8"},"seq_nr":1,"name":"test","members":{"members_ids_by_user_account_id":{"01H42KBHCWBDTZYQ7P78T8BTWX":"01H42KBHCWA8NE32M49YH544H1"},"members":{"01H42KBHCWA8NE32M49YH544H1":{"id":"01H42KBHCWA8NE32M49YH544H1","user_account_id":{"value":"01890535-c59c-5b75-ff5c-f63a3485eb9d"},"role":"Admin"}}},"occurred_at":"2023-06-29T03:32:37.404481Z"} |         |
-| occurred_at | Occurred DateTime of the Event                                       | 2023-06-29T03:32:37.404481Z                                                                                                                                                                                                                                                                                                                                                                                                                                        |         |
+| attribute name | type | description | example |
+|:------------|:----|:---------------------------------------------------------------------|:--------|
+| pkey        | S | Partition key (`${aggregate-type-name}-hash($aid) % logical-shard-size`) | `user-account-1` |
+| skey        | S | Sort key (`${aggregate-type-name}-${aid.value}-${seq_nr}`) | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-12345` |
+| aid         | S | Aggregate ID | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z` |
+| seq_nr      | N | Sequence number (origin=1, domain-numbered) | `12345` |
+| payload     | B | Event payload — pure domain content, serialized JSON by default | `{"Created":{"name":"test"}}` |
+| occurred_at | N | Occurred datetime of the event in Unix epoch **nanoseconds** (domain-supplied; round-trips exactly) | `1688009557404481000` |
+| manifest    | S | User-supplied, free-form type discriminator carried by the envelope (empty string when omitted) | `user-account-created/v1` |
 
-GSI is applied to aid and seq_nr, and this index is used during replay.
+A GSI on `(aid, seq_nr)` is used during replay.
 
 ### Snapshot table
 
-This table is used to store aggregate state and to speed up replay of aggregates. It may not represent the latest aggregation state because events are saved even after the snapshot is saved.
+This table is used to store aggregate state and to speed up replay of aggregates. It may not represent the latest aggregate state because events are saved even after the snapshot is saved.
 
-| column name | description                                                                                               | example                                                                                                                                                                                                                                                                                                                                                                                    | remarks |
-|:------------|:----------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|
-| pkey        | Partition key(${aggregate-type-name}-hash($aid) % logical-shard-size)                                      | user-account-1                                                                                                                                                                                                                                                                                                                                                                               |         |
-| skey        | Sort Key(${aggregate type name}-${aid.value}-${seq_nr}), The latest snapshot is read/written as seq_nr=0. | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-12345                                                                                                                                                                                                                                                                                                                                                |         |
-| payload     | State of Aggregate                                                                                        | {"id":{"value":"0189053a-d0b4-8f9b-4fb6-db91f72ccf16"},"name":"test","members":{"members_ids_by_user_account_id":{"01H42KNM5MBVRBZTADAZ9ETSPZ":"01H42KNM5M2QEW700VCW4J2KYE"},"members":{"01H42KNM5M2QEW700VCW4J2KYE":{"id":"01H42KNM5M2QEW700VCW4J2KYE","user_account_id":{"value":"0189053a-d0b4-5ef0-bfe9-4d57d2ed66df"},"role":"Admin"}}},"messages":[],"seq_nr_counter":1,"version":1} |         |
-| aid         | Aggregate ID                                                                                              | user-account-01H42K4ABWQ5V2XQEP3A48VE0Z                                                                                                                                                                                                                                                                                                                                                      |         |
-| ser_nr      | Sequence Number(origin=1)                                                                                 | 12345                                                                                                                                                                                                                                                                                                                                                                                      |         |
-| ttl         | TTL for deletion(seconds)                                                                                 | 1624980000                                                                                                                                                                                                                                                                                                                                                                                 |         |
-| version     | Version for optimistic lock(origin=1)                                                                     | 1                                                                                                                                                                                                                                                                                                                                                                                          |         |
+| attribute name | type | description | example |
+|:------------|:----|:-----------------------------------------------------------------------------------------------|:--------|
+| pkey        | S | Partition key (`${aggregate-type-name}-hash($aid) % logical-shard-size`) | `user-account-1` |
+| skey        | S | Sort key (`${aggregate-type-name}-${aid.value}-${seq_nr}`). The current snapshot lives in the slot whose skey is formatted with the **marker `0`**; history items use the event's seq_nr | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z-0` |
+| aid         | S | Aggregate ID | `user-account-01H42K4ABWQ5V2XQEP3A48VE0Z` |
+| seq_nr      | N | Sequence number the snapshot reflects. **Unlike v2, the current item stores the real value** (the marker `0` appears only inside the skey) | `12345` |
+| version     | N | Version for optimistic locking (origin=1). The column value is authoritative — it is never recovered from the payload | `1` |
+| payload     | B | State of the aggregate — pure domain content, serialized JSON by default (no injected `version` / `seq_nr`) | `{"id":{"value":"..."},"name":"test"}` |
+| ttl         | N | TTL for deletion in epoch seconds (`0` = no expiry; set on excess history items when `with_delete_ttl` is configured) | `1624980000` |
+| last_updated_at | N | Last updated datetime in Unix epoch milliseconds (derived from the event's `occurred_at`) | `1688009557404` |
 
-- When the snapshot redundancy feature is disabled, only a snapshot is stored at skey=0. When enabled, two snapshots are stored at skey=aggregate.seq_nr() in addition to skey=0. Each time a snapshot is saved, skey=aggregate.seq_nr() snapshot will be increased, but you can specify an upper limit for the snapshot (default is 1). If the upper limit is exceeded, the older snapshots will be deleted first. By default, the deletion is client-initiated; you can also use TTL to let DynamoDB itself do the deletion.
-- GSI is applied to aid and seq_nr, and this index is used during replay.
+- The current snapshot is read by a strongly consistent `GetItem` on the primary key
+  (`pkey` + the marker-`0` skey); its `version` is what callers pass back as
+  `expected_version` on the next write.
+- History items (skey = event seq_nr) are written **only when
+  `with_keep_snapshot_count(Some(n))` is enabled**, inside the same transaction as the
+  current item and the journal item.
+- The GSI on `(aid, seq_nr)` is used by the retention query; the excess above
+  `n` history items is either deleted or, when `with_delete_ttl` is configured, given a
+  future `ttl` value so DynamoDB expires the items (see the asymmetry note above:
+  the pruned excess is taken from the newest side).
 
 ### Writing events and snapshots
 
-1. When the command is accepted by aggregate, an event with the latest seq_nr is generated. 
-2. The generated events are written to the journal table. However, this write is always done in the same transaction as the snapshot table and under version matching conditions. Except for the first event, updating the payload of snapshot is optional.
+1. When the command is accepted by the aggregate, the domain produces the next event
+   and wraps it in an `EventEnvelope` with `seq_nr` numbered by the domain (origin=1).
+2. The journal Put and the snapshot write always run in one `TransactWriteItems`.
+   The first event of a stream (seq_nr=1, expected_version=0) creates both items with
+   condition `attribute_not_exists`; every later write updates the current snapshot item
+   under the condition `version = expected_version` and sets `version = expected_version + 1`.
+   A failed condition surfaces as `OptimisticLockError`.
 
 ### Replaying an aggregate with events and snapshots
 
-1. Specify the ID of the aggregate and take a snapshot.
-2. Read the events from the journal table after the ID of the retrieved aggregate and the sequence number of the snapshot.
-3. Apply the read events to the snapshot to obtain the latest aggregate state.
+1. Specify the ID of the aggregate and get the latest `SnapshotEnvelope`.
+2. Read the events after the envelope's `seq_nr` from the journal table.
+3. Apply the read events to the snapshot state to obtain the latest aggregate state;
+   pass the envelope's `version` as `expected_version` on the next write.
+
+## Bigtable table schema used by EventStoreForBigtable
+
+- journal table — column family `event`
+- snapshot table — column family `snapshot`
+
+All values are stored as bytes; numeric cells hold decimal strings. Reads and the
+CAS predicate use a cells-per-column limit of 1, so the latest cell of each column
+is authoritative.
+
+### journal table (Bigtable)
+
+Row key: `${partition-key}#${aggregate-type-name}#${aid.value}#${seq_nr zero-padded to 20 digits}`
+(the partition key is `${aggregate-type-name}-hash($aid) % shard-count`). One `EventEnvelope` maps to one row.
+
+| column (family `event`) | description | example |
+|:------------|:---------------------------------------------------------------------|:--------|
+| payload     | Event payload — pure domain content, serialized JSON by default | `{"Created":{"name":"test"}}` |
+| aggregate_id | Aggregate ID value part | `01H42K4ABWQ5V2XQEP3A48VE0Z` |
+| seq_nr      | Sequence number (origin=1, domain-numbered) | `12345` |
+| occurred_at | Occurred datetime as an RFC 3339 string with **nanosecond** precision (domain-supplied; round-trips exactly) | `2023-06-29T03:32:37.404481000Z` |
+| manifest    | User-supplied, free-form type discriminator (empty string when omitted) | `user-account-created/v1` |
+
+The zero-padded seq_nr keeps the row keys of one aggregate contiguous and ordered,
+so replay is a prefix range scan.
+
+### snapshot table (Bigtable)
+
+Current row key: `${partition-key}#${aggregate-type-name}#${aid.value}`.
+History row key: current row key + `#` + zero-padded seq_nr (key order = oldest first).
+
+| column (family `snapshot`) | description | example |
+|:------------|:---------------------------------------------------------------------|:--------|
+| payload     | State of the aggregate — pure domain content (no injected `version` / `seq_nr`) | `{"id":{"value":"..."},"name":"test"}` |
+| seq_nr      | Sequence number the snapshot reflects | `12345` |
+| version     | Version for optimistic locking (origin=1); the cell value is authoritative | `1` |
+| last_updated_at | Last updated datetime in Unix epoch milliseconds | `1688009557404` |
+
+- Writes go through `CheckAndMutateRow` (single-row atomic CAS): creation asserts the
+  absence of the `version` cell; updates assert `version == expected_version` byte-exactly
+  and set `version = expected_version + 1`. A failed predicate surfaces as
+  `OptimisticLockError`.
+- History rows are written **only when `with_keep_snapshot_count(Some(n))` is enabled**:
+  the CAS winner copies the pre-image of the current row to the history row key in a
+  separate best-effort write.
+- Retention keeps the newest `n` history rows and deletes the oldest excess
+  (`DeleteFromRow`); `with_delete_ttl` additionally deletes history rows whose
+  `last_updated_at` is older than the TTL.
 
 ## SQLite table schema used by EventStoreForSqlite
 
 - journal
 - snapshot
 
-**This section is informational.** The tables and indexes are created automatically by the library when the store is constructed (idempotent `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`); you never run this DDL yourself.
+The tables and indexes are created automatically by the library when the store is constructed (idempotent `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`) — no user DDL is required or expected.
 
-The key design mirrors the DynamoDB tables: `pkey` / `skey` form the write address (`PRIMARY KEY (pkey, skey)`) and distribute writes across logical shards, while `(aid, seq_nr)` is the read key used to replay an aggregate.
+The key design mirrors the DynamoDB tables: `pkey` / `skey` form the write address (`PRIMARY KEY (pkey, skey)`) and distribute writes across logical shards, while `(aid, seq_nr)` is the read key used for replay.
 
 ```sql
 CREATE TABLE IF NOT EXISTS journal (
@@ -65,6 +157,7 @@ CREATE TABLE IF NOT EXISTS journal (
   seq_nr INTEGER NOT NULL,
   payload BLOB NOT NULL,
   occurred_at INTEGER NOT NULL,
+  manifest TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (pkey, skey)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS journal_aid_seq_nr_idx ON journal (aid, seq_nr);
@@ -88,9 +181,10 @@ CREATE INDEX IF NOT EXISTS snapshot_aid_seq_nr_idx ON snapshot (aid, seq_nr);
 | pkey | TEXT | Partition key (`${aggregate-type-name}-hash($aid) % shard-count`) — write-distribution key, part of the primary key |
 | skey | TEXT | Sort key (`${aggregate-type-name}-${aid.value}-${seq_nr}`) — part of the primary key |
 | aid | TEXT | Aggregate ID |
-| seq_nr | INTEGER | Sequence number (origin=1) |
-| payload | BLOB | Event payload (serialized JSON by default) |
-| occurred_at | INTEGER | Occurred datetime of the event in Unix epoch milliseconds |
+| seq_nr | INTEGER | Sequence number (origin=1, domain-numbered) |
+| payload | BLOB | Event payload — pure domain content (serialized JSON by default) |
+| occurred_at | INTEGER | Occurred datetime of the event in Unix epoch **nanoseconds** (domain-supplied; round-trips exactly; out-of-range values are rejected at write time) |
+| manifest | TEXT | User-supplied, free-form type discriminator carried by the envelope (empty string when omitted) |
 
 A unique index on `(aid, seq_nr)` plays the role of the DynamoDB GSI and is used during replay.
 
@@ -99,14 +193,21 @@ A unique index on `(aid, seq_nr)` plays the role of the DynamoDB GSI and is used
 | column name | type | description |
 |:------------|:-----|:------------|
 | pkey | TEXT | Partition key (`${aggregate-type-name}-hash($aid) % shard-count`) — write-distribution key, part of the primary key |
-| skey | TEXT | Sort key (`${aggregate-type-name}-${aid.value}-${seq_nr}`); the latest snapshot is read/written as seq_nr=0 | 
+| skey | TEXT | Sort key (`${aggregate-type-name}-${aid.value}-${seq_nr}`). The current snapshot lives in the slot whose skey is formatted with the **marker `0`**; history rows use the event's seq_nr |
 | aid | TEXT | Aggregate ID |
-| seq_nr | INTEGER | Sequence number (the current-slot row keeps 0; history rows keep the aggregate's seq_nr) |
-| version | INTEGER | Version for optimistic locking (origin=1) |
-| payload | BLOB | State of the aggregate (serialized JSON by default) |
+| seq_nr | INTEGER | Sequence number the snapshot reflects. **Unlike v2, the current row stores the real value** (the marker `0` appears only inside the skey; current/history discrimination is by skey, not by this column) |
+| version | INTEGER | Version for optimistic locking (origin=1); the column value is authoritative — it is never recovered from the payload |
+| payload | BLOB | State of the aggregate — pure domain content (serialized JSON by default, no injected `version` / `seq_nr`) |
 | last_updated_at | INTEGER | Last updated datetime in Unix epoch milliseconds; also used to evaluate the snapshot retention TTL |
 
 An index on `(aid, seq_nr)` is used during replay.
 
-- Optimistic-lock verification and writes happen inside a single SQLite transaction: the journal insert and the conditional snapshot update (`WHERE version = expected`) either commit together or roll back together. A version mismatch is returned as `OptimisticLockError`.
-- When snapshot retention is enabled via `with_keep_snapshot_count`, history snapshot rows (seq_nr > 0) are inserted in addition to the seq_nr=0 slot, and excess/expired history rows are deleted client-initiated after each persist. `with_delete_ttl` takes effect only when a retention count is also configured (contract-symmetric with the DynamoDB backend); on its own it records no history. Unlike DynamoDB there is no storage-side TTL; the deletion is always performed by the library.
+- Optimistic-lock verification and writes happen inside a single SQLite transaction:
+  the journal insert and the conditional snapshot update (`WHERE version = expected`)
+  either commit together or roll back together. The first event of a stream
+  (seq_nr=1, expected_version=0) inserts both rows; a primary-key / unique-index
+  conflict on that path surfaces as `OptimisticLockError` with `expected_version=0`.
+- History rows are inserted **only when `with_keep_snapshot_count(Some(n))` is enabled**,
+  in the same transaction. Retention keeps the newest `n` history rows and deletes the
+  oldest excess (`ORDER BY seq_nr ASC LIMIT excess`); `with_delete_ttl` additionally
+  deletes history rows whose `last_updated_at` is older than the TTL.

--- a/docs/MIGRATION_GUIDE_v3.ja.md
+++ b/docs/MIGRATION_GUIDE_v3.ja.md
@@ -1,0 +1,157 @@
+# 移行ガイド: v2 → v3（EventEnvelope API）
+
+v3 は `Event` / `Aggregate` トレイト契約を封筒ベースの API に置き換えます。
+ドメインイベントと集約状態はプレーンな serde 型（payload）になり、ストアが必要と
+するメタデータは 2 つの新しい公開型が運搬します。
+
+- [`EventEnvelope<AID, P>`] — journal 1 行に対応: `aggregate_id` / `seq_nr` /
+  `occurred_at` / `manifest` + イベント payload。
+- [`SnapshotEnvelope<A>`] — スナップショット 1 件に対応: 集約 payload + `seq_nr`
+  （リプレイ開始位置）と `version`（楽観的ロックの版数）。
+
+これは破壊的リリースです。**v3 は v2 で書き込まれた行を読み取りません** — 後述の
+[データ互換性](#データ互換性)を参照してください。
+
+## 破壊的変更の一覧
+
+| 領域 | v2 | v3 |
+|:-----|:---|:---|
+| ドメイントレイト | `E: Event`、`A: Aggregate`（`id()`, `seq_nr()`, `version()`, `set_version()` など） | 廃止。payload に必要なのは `Serialize + DeserializeOwned + Send + Sync + 'static` のみ（`AggregateId` は存続） |
+| 書き込み API | `persist_event(&event, version)`、`persist_event_and_snapshot(&event, &aggregate)` | `persist_event(EventEnvelope, expected_version)`、`persist_event_and_snapshot(EventEnvelope, aggregate, expected_version)` — 封筒・payload とも値渡し |
+| 読み取り API | `get_latest_snapshot_by_id -> Option<A>`、`get_events_by_id_since_seq_nr -> Vec<E>` | `-> Option<SnapshotEnvelope<A>>`、`-> Vec<EventEnvelope<AID, P>>` — メタデータが境界を越えて保持される |
+| version の管理 | ストアが `set_version` で集約へ書き戻し | スナップショットの列／セルが正。`SnapshotEnvelope::version()` から読む |
+| 直列化 payload | ライブラリが保存 JSON へ `seq_nr` / `version` を注入 | payload 列は純粋なドメイン内容のみ。メタデータは専用列に置かれる |
+| シリアライザ | トレイト境界付き型に対する `EventSerializer<E>` / `SnapshotSerializer<A>` | payload 専用の `EventSerializer<P>` / `SnapshotSerializer<A>`。`deserialize` は payload を直接返す |
+| `with_keep_snapshot_count` | `Self`（検証なし） | `Result<Self, EventStoreWriteError>`。**`Some(0)` は拒否**（無効化は `None`） |
+| エラー | `OptimisticLockError`、`SerializationError`、`IOError`、`OtherError` | + **`ContractViolation`**（書き込み契約に違反する呼び出し。後述） |
+| 不在集約への更新 | バックエンド依存 | 一律 `OptimisticLockError`（`actual_version` なしの書式） |
+| Bigtable の CAS | 非トランザクションの read→check→write | 単一行原子性の `CheckAndMutateRow` |
+| MSRV | 未宣言 | `rust-version = "1.94.1"`（`--all-features` で実測） |
+
+Cargo feature の構成は変更ありません: `default = []`、バックエンドは `dynamodb` /
+`bigtable` / `sqlite` / `sqlite-system` のオプトイン、インメモリバックエンドは常時
+コンパイルされます。
+
+## 1. ドメイン型からメタデータを剥がす
+
+`Event` / `Aggregate` の実装と、それらを満たすためだけに存在していたフィールド
+（`seq_nr`、`version`、`last_updated_at`、ドメインデータとして不要ならイベント ID や
+集約 ID の複製も）を削除します。
+
+```rust
+// v2
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UserAccountEvent {
+  Created { id: ULID, aggregate_id: UserAccountId, seq_nr: usize, name: String, occurred_at: DateTime<Utc> },
+  Renamed { id: ULID, aggregate_id: UserAccountId, seq_nr: usize, name: String, occurred_at: DateTime<Utc> },
+}
+impl Event for UserAccountEvent { /* ... */ }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserAccount { id: UserAccountId, name: String, seq_nr: usize, version: usize, last_updated_at: DateTime<Utc> }
+impl Aggregate for UserAccount { /* ... set_version ... */ }
+```
+
+```rust
+// v3 — ライブラリトレイトなしのプレーンな serde 型
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum UserAccountEvent {
+  Created { name: String },
+  Renamed { name: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserAccount { id: UserAccountId, name: String }
+```
+
+`AggregateId` は変更なしで、ID 型には引き続き必要です。
+
+## 2. 書き込みを封筒に包む
+
+イベントの採番はドメイン側の責務です: `seq_nr` は 1 始まりで、同一ストリーム内で
+連続している必要があります（ライブラリは連続性を検証しません。重複は楽観的ロックが
+拒否し、飛び番はそのまま書き込まれます）。`occurred_at` はドメイン供給値で、ナノ秒
+精度のまま完全往復します。`manifest` は省略可能・自由形式の型判別子です（省略時は
+空文字列）。
+
+`expected_version` の規約（違反は `EventStoreWriteError::ContractViolation`）:
+
+- 新規作成: `seq_nr == 1` **かつ** `expected_version == 0`。
+  `persist_event_and_snapshot` を使う。
+- 更新: 読取済み `SnapshotEnvelope` の `version()` を渡す。
+  `persist_event` は `seq_nr == 1` を受け付けない。
+
+```rust
+// 新規作成
+let (state, created) = UserAccount::new(id.clone(), "alice".to_string());
+let envelope = EventEnvelope::new(id.clone(), 1, Utc::now(), created)
+  .with_manifest("user-account-created/v1");
+event_store.persist_event_and_snapshot(envelope, state, 0).await?;
+
+// 更新（イベントのみ）
+let envelope = EventEnvelope::new(id.clone(), replayed.seq_nr + 1, Utc::now(), renamed);
+event_store.persist_event(envelope, replayed.version).await?;
+```
+
+## 3. 封筒からリプレイする
+
+読み取りは封筒を返すため、リプレイ位置と次回の `expected_version` は集約フィールド
+ではなくストアから得ます。
+
+```rust
+pub struct ReplayedUserAccount {
+  pub state: UserAccount,
+  pub seq_nr: usize,   // 適用済み最後のイベント位置。次のイベントは seq_nr + 1 で採番する
+  pub version: usize,  // 次回書込の expected_version として渡す
+}
+
+async fn find_by_id(store: &impl EventStore<AID = UserAccountId, A = UserAccount, P = UserAccountEvent>,
+                    id: &UserAccountId) -> Result<Option<ReplayedUserAccount>, ...> {
+  let snapshot = match store.get_latest_snapshot_by_id(id).await? {
+    Some(snapshot) => snapshot,
+    None => return Ok(None),
+  };
+  let snapshot_seq_nr = snapshot.seq_nr();
+  let version = snapshot.version();
+  let events = store.get_events_by_id_since_seq_nr(id, snapshot_seq_nr + 1).await?;
+  let seq_nr = events.last().map(|e| e.seq_nr()).unwrap_or(snapshot_seq_nr);
+  let state = UserAccount::replay(events.into_iter().map(EventEnvelope::into_payload),
+                                  snapshot.into_aggregate());
+  Ok(Some(ReplayedUserAccount { state, seq_nr, version }))
+}
+```
+
+実行可能な examples（`examples/user-account`、`examples/user-account-sqlite`）が
+まさにこのパターンを実装しています。
+
+## 4. ビルダーとエラー処理を調整する
+
+- `with_keep_snapshot_count` は `Result<Self, EventStoreWriteError>` を返すように
+  なり、全バックエンド一律で `Some(0)` を拒否します（無効化は `None`。履歴行は
+  `Some(n)` の間だけ書かれます）。剪定でどの履歴行が残るかはバックエンドごとに
+  異なります — [保持の非対称の注記](DATABASE_SCHEMA.ja.md#スナップショット保持のバックエンド間非対称)
+  を参照してください。
+- 書き込みエラーを網羅的に match している箇所には、新しい
+  `EventStoreWriteError::ContractViolation` を追加してください。これはストレージ
+  障害ではなく、呼び出し側の契約違反（`seq_nr == 0`、新規作成／更新の対応崩れ、
+  `keep_snapshot_count == 0`）を表します。
+- 存在しない集約への更新は、一律で
+  `optimistic lock failed, aid=<id>, expected_version=<n>`（`actual_version` なし）
+  という書式の `OptimisticLockError` を返します。
+
+## データ互換性
+
+**v3 は v2 で書き込まれたデータを読み取らず、移行ツールや互換レイヤも提供しません。**
+物理レイアウトは全バックエンドで変更されています（journal の `manifest` 列、ナノ秒
+`occurred_at`、純化された payload、キーによる current/履歴判別 —
+[DATABASE_SCHEMA.ja.md](DATABASE_SCHEMA.ja.md) を参照）。既存の保存データの移行 —
+たとえば v2 リーダーで v2 ストリームをリプレイし v3 で再永続化するなど — は
+アプリケーションの責務です。保持すべきデータがあるシステムでは、アップグレード前に
+新規ストリームでの再出発か一回限りの変換を計画してください。
+
+## MSRV
+
+v3 は `lib/Cargo.toml` に `rust-version = "1.94.1"` を宣言しています。これは新規の
+依存解決で `--all-features` がビルドできる最小ツールチェーンの実測値です（現時点で
+AWS SDK スタックが 1.94.1 を要求します）。feature を絞ったビルドはより古いツール
+チェーンでも動く可能性がありますが、cargo は宣言値をパッケージ全体に強制します。

--- a/docs/MIGRATION_GUIDE_v3.md
+++ b/docs/MIGRATION_GUIDE_v3.md
@@ -1,0 +1,159 @@
+# Migration Guide: v2 → v3 (the EventEnvelope API)
+
+v3 replaces the `Event` / `Aggregate` trait contract with an envelope-based API.
+Domain events and aggregate state become plain serde types (payloads), and the
+metadata the store needs travels in two new public types:
+
+- [`EventEnvelope<AID, P>`] — one journal row: `aggregate_id` / `seq_nr` /
+  `occurred_at` / `manifest` + the event payload.
+- [`SnapshotEnvelope<A>`] — one snapshot: the aggregate payload + `seq_nr`
+  (replay start position) and `version` (optimistic-lock version).
+
+This is a breaking release. **v3 does not read rows written by v2** — see
+[Data compatibility](#data-compatibility) below.
+
+## Breaking changes at a glance
+
+| Area | v2 | v3 |
+|:-----|:---|:---|
+| Domain traits | `E: Event`, `A: Aggregate` (with `id()`, `seq_nr()`, `version()`, `set_version()`, ...) | Removed. Payloads only need `Serialize + DeserializeOwned + Send + Sync + 'static` (`AggregateId` remains) |
+| Write API | `persist_event(&event, version)`, `persist_event_and_snapshot(&event, &aggregate)` | `persist_event(EventEnvelope, expected_version)`, `persist_event_and_snapshot(EventEnvelope, aggregate, expected_version)` — envelopes and payloads by value |
+| Read API | `get_latest_snapshot_by_id -> Option<A>`, `get_events_by_id_since_seq_nr -> Vec<E>` | `-> Option<SnapshotEnvelope<A>>`, `-> Vec<EventEnvelope<AID, P>>` — metadata survives the boundary |
+| Version bookkeeping | Store wrote the version back into the aggregate via `set_version` | The snapshot column/cell is authoritative; read it from `SnapshotEnvelope::version()` |
+| Serialized payloads | Library injected `seq_nr` / `version` metadata into stored JSON | Payload columns hold pure domain content; metadata lives in dedicated columns |
+| Serializers | `EventSerializer<E>` / `SnapshotSerializer<A>` over trait-bound types | Payload-only `EventSerializer<P>` / `SnapshotSerializer<A>`; `deserialize` returns the payload directly |
+| `with_keep_snapshot_count` | `Self` (no validation) | `Result<Self, EventStoreWriteError>`; **`Some(0)` is rejected** (use `None` to disable retention) |
+| Errors | `OptimisticLockError`, `SerializationError`, `IOError`, `OtherError` | + **`ContractViolation`** for calls that break the write contract (see below) |
+| Update of an absent aggregate | Backend-dependent | Uniformly `OptimisticLockError` (message without `actual_version`) |
+| Bigtable CAS | Non-transactional read→check→write | Single-row atomic `CheckAndMutateRow` |
+| MSRV | Undeclared | `rust-version = "1.94.1"` (measured with `--all-features`) |
+
+The Cargo feature set is unchanged: `default = []`, backends are opt-in via
+`dynamodb` / `bigtable` / `sqlite` / `sqlite-system`, and the in-memory backend is
+always compiled.
+
+## 1. Strip the metadata from your domain types
+
+Delete the `Event` / `Aggregate` implementations and every field that only existed
+to satisfy them (`seq_nr`, `version`, `last_updated_at`, per-event IDs and
+aggregate-ID copies if you do not need them as domain data):
+
+```rust
+// v2
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UserAccountEvent {
+  Created { id: ULID, aggregate_id: UserAccountId, seq_nr: usize, name: String, occurred_at: DateTime<Utc> },
+  Renamed { id: ULID, aggregate_id: UserAccountId, seq_nr: usize, name: String, occurred_at: DateTime<Utc> },
+}
+impl Event for UserAccountEvent { /* ... */ }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserAccount { id: UserAccountId, name: String, seq_nr: usize, version: usize, last_updated_at: DateTime<Utc> }
+impl Aggregate for UserAccount { /* ... set_version ... */ }
+```
+
+```rust
+// v3 — plain serde types, no library traits
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum UserAccountEvent {
+  Created { name: String },
+  Renamed { name: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserAccount { id: UserAccountId, name: String }
+```
+
+`AggregateId` is unchanged and still required for the ID type.
+
+## 2. Wrap writes in envelopes
+
+The domain numbers events itself: `seq_nr` starts at 1 and must be contiguous per
+stream (the library does not validate contiguity; duplicates are rejected by the
+optimistic lock, gaps are written as-is). `occurred_at` is domain-supplied and
+round-trips exactly (nanosecond precision). `manifest` is an optional free-form
+type discriminator (empty string when omitted).
+
+The `expected_version` convention (enforced, violations return
+`EventStoreWriteError::ContractViolation`):
+
+- creation: `seq_nr == 1` **and** `expected_version == 0`, via
+  `persist_event_and_snapshot`;
+- update: pass the `version()` of the `SnapshotEnvelope` you read;
+  `persist_event` refuses `seq_nr == 1`.
+
+```rust
+// creation
+let (state, created) = UserAccount::new(id.clone(), "alice".to_string());
+let envelope = EventEnvelope::new(id.clone(), 1, Utc::now(), created)
+  .with_manifest("user-account-created/v1");
+event_store.persist_event_and_snapshot(envelope, state, 0).await?;
+
+// update (event only)
+let envelope = EventEnvelope::new(id.clone(), replayed.seq_nr + 1, Utc::now(), renamed);
+event_store.persist_event(envelope, replayed.version).await?;
+```
+
+## 3. Replay from envelopes
+
+Reads return envelopes, so the replay position and the next `expected_version`
+come from the store instead of from aggregate fields:
+
+```rust
+pub struct ReplayedUserAccount {
+  pub state: UserAccount,
+  pub seq_nr: usize,   // last applied event position; number the next event as seq_nr + 1
+  pub version: usize,  // pass as expected_version on the next write
+}
+
+async fn find_by_id(store: &impl EventStore<AID = UserAccountId, A = UserAccount, P = UserAccountEvent>,
+                    id: &UserAccountId) -> Result<Option<ReplayedUserAccount>, ...> {
+  let snapshot = match store.get_latest_snapshot_by_id(id).await? {
+    Some(snapshot) => snapshot,
+    None => return Ok(None),
+  };
+  let snapshot_seq_nr = snapshot.seq_nr();
+  let version = snapshot.version();
+  let events = store.get_events_by_id_since_seq_nr(id, snapshot_seq_nr + 1).await?;
+  let seq_nr = events.last().map(|e| e.seq_nr()).unwrap_or(snapshot_seq_nr);
+  let state = UserAccount::replay(events.into_iter().map(EventEnvelope::into_payload),
+                                  snapshot.into_aggregate());
+  Ok(Some(ReplayedUserAccount { state, seq_nr, version }))
+}
+```
+
+The runnable examples (`examples/user-account`, `examples/user-account-sqlite`)
+implement exactly this pattern.
+
+## 4. Adjust builder and error handling
+
+- `with_keep_snapshot_count` now returns
+  `Result<Self, EventStoreWriteError>` and rejects `Some(0)` uniformly across all
+  backends (`None` disables retention; history rows are only written while it is
+  `Some(n)`). Which history rows survive pruning differs per backend — see the
+  [retention asymmetry note](DATABASE_SCHEMA.md#snapshot-retention-asymmetry-across-backends).
+- Match the new `EventStoreWriteError::ContractViolation` variant where you
+  exhaustively match write errors. It signals a caller-side contract break
+  (`seq_nr == 0`, creation/update mismatch, `keep_snapshot_count == 0`), not a
+  storage failure.
+- An update addressed at an aggregate that does not exist now uniformly returns
+  `OptimisticLockError` with the message form
+  `optimistic lock failed, aid=<id>, expected_version=<n>` (no `actual_version`).
+
+## Data compatibility
+
+**v3 does not read data written by v2, and no migration tooling or compatibility
+layer is provided.** The physical layout changed in all backends (journal
+`manifest` column, nanosecond `occurred_at`, pure payloads, key-based
+current/history discrimination — see [DATABASE_SCHEMA.md](DATABASE_SCHEMA.md)).
+Migrating existing stored data — for example by replaying v2 streams through a
+v2 reader and re-persisting them through v3 — is the responsibility of the
+application. Plan for new streams or a one-off conversion before upgrading a
+system with data you need to keep.
+
+## MSRV
+
+v3 declares `rust-version = "1.94.1"` in `lib/Cargo.toml`, measured as the minimum
+toolchain that builds `--all-features` with a fresh dependency resolution (the AWS
+SDK stack currently requires 1.94.1). Feature-limited builds may work on older
+toolchains, but cargo enforces the declared floor for the whole package.

--- a/examples/user-account-sqlite/src/main.rs
+++ b/examples/user-account-sqlite/src/main.rs
@@ -1,13 +1,18 @@
 use std::env;
 
-use event_store_adapter_rs::types::Aggregate;
+use chrono::Utc;
+use event_store_adapter_rs::event_envelope::EventEnvelope;
 use event_store_adapter_rs::EventStoreForSqlite;
 
-use crate::user_account::{id_generate, UserAccount, UserAccountId};
+use crate::user_account::{id_generate, UserAccount, UserAccountId, CREATED_MANIFEST, RENAMED_MANIFEST};
 use crate::user_account_repository::{RepositoryError, UserAccountRepository};
 
 mod user_account;
 mod user_account_repository;
+
+// FR8.4: v3 envelope-API walkthrough. Creation persists a seq_nr=1 envelope with
+// expected_version=0; updates number the next envelope from the replayed seq_nr and pass the
+// replayed version as expected_version (BR2.3 / BR2.6).
 
 #[tokio::main]
 async fn main() {
@@ -49,10 +54,10 @@ async fn create_user_account(
   name: &str,
 ) -> Result<UserAccountId, RepositoryError> {
   let user_account_id = UserAccountId::new(id.to_string());
-  let (user_account, user_account_event) = UserAccount::new(user_account_id.clone(), name.to_string());
-  repository
-    .store_event_and_snapshot(&user_account_event, &user_account)
-    .await?;
+  let (user_account, created) = UserAccount::new(user_account_id.clone(), name.to_string());
+  // The first event of a stream is seq_nr == 1 and is written with expected_version == 0 (BR2.6).
+  let envelope = EventEnvelope::new(user_account_id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST);
+  repository.store_event_and_snapshot(envelope, user_account, 0).await?;
   Ok(user_account_id)
 }
 
@@ -61,9 +66,11 @@ async fn rename_user_account(
   user_account_id: &UserAccountId,
   name: &str,
 ) -> Result<(), RepositoryError> {
-  let mut user_account = repository.find_by_id(user_account_id).await?.unwrap();
-  let user_account_event = user_account.rename(name).unwrap();
-  repository
-    .store_event(&user_account_event, user_account.version())
-    .await
+  let mut replayed = repository.find_by_id(user_account_id).await?.unwrap();
+  let renamed = replayed.state.rename(name).unwrap();
+  // The domain numbers the next event as replayed seq_nr + 1 (FR3.3) and passes the replayed
+  // version as expected_version for the optimistic lock (FR2.2).
+  let envelope = EventEnvelope::new(user_account_id.clone(), replayed.seq_nr + 1, Utc::now(), renamed)
+    .with_manifest(RENAMED_MANIFEST);
+  repository.store_event(envelope, replayed.version).await
 }

--- a/examples/user-account-sqlite/src/user_account.rs
+++ b/examples/user-account-sqlite/src/user_account.rs
@@ -1,11 +1,14 @@
-use chrono::{DateTime, Utc};
-use event_store_adapter_rs::types::{Aggregate, AggregateId, Event};
+use event_store_adapter_rs::types::AggregateId;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::sync::{Mutex, OnceLock};
 use ulid_generator_rs::{ULIDGenerator, ULID};
 
-/// Generates a ULID used as an event ID.
+// FR8.4 / FR3.1 / FR3.2: v3 example domain model. The `Event` / `Aggregate` traits are gone;
+// the event and the aggregate state are plain serde types (payloads), and the metadata
+// (aggregate_id / seq_nr / occurred_at / manifest) travels in the envelopes.
+
+/// Generates a ULID used as an aggregate ID.
 pub fn id_generate() -> ULID {
   static GENERATOR: OnceLock<Mutex<ULIDGenerator>> = OnceLock::new();
   let mut generator = GENERATOR
@@ -14,6 +17,11 @@ pub fn id_generate() -> ULID {
     .expect("ULID generator mutex is poisoned");
   generator.generate().expect("failed to generate a ULID")
 }
+
+/// Manifest value carried by the creation event envelope (FR1.2 — user-supplied, free-form).
+pub const CREATED_MANIFEST: &str = "user-account-created/v1";
+/// Manifest value carried by the rename event envelope.
+pub const RENAMED_MANIFEST: &str = "user-account-renamed/v1";
 
 #[derive(Debug)]
 pub enum UserAccountError {
@@ -47,103 +55,38 @@ impl AggregateId for UserAccountId {
   }
 }
 
+/// Event payload: pure domain content only — no event ID, no seq_nr, no timestamp.
+/// The envelope carries those (FR1.1).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum UserAccountEvent {
-  Created {
-    id: ULID,
-    aggregate_id: UserAccountId,
-    seq_nr: usize,
-    name: String,
-    occurred_at: DateTime<Utc>,
-  },
-  Renamed {
-    id: ULID,
-    aggregate_id: UserAccountId,
-    seq_nr: usize,
-    name: String,
-    occurred_at: DateTime<Utc>,
-  },
+  Created { name: String },
+  Renamed { name: String },
 }
 
-impl Event for UserAccountEvent {
-  type AggregateID = UserAccountId;
-  type ID = ULID;
-
-  fn id(&self) -> &Self::ID {
-    match self {
-      UserAccountEvent::Created { id, .. } => id,
-      UserAccountEvent::Renamed { id, .. } => id,
-    }
-  }
-
-  fn aggregate_id(&self) -> &Self::AggregateID {
-    match self {
-      UserAccountEvent::Created { aggregate_id, .. } => aggregate_id,
-      UserAccountEvent::Renamed { aggregate_id, .. } => aggregate_id,
-    }
-  }
-
-  fn seq_nr(&self) -> usize {
-    match self {
-      UserAccountEvent::Created { seq_nr, .. } => *seq_nr,
-      UserAccountEvent::Renamed { seq_nr, .. } => *seq_nr,
-    }
-  }
-
-  fn occurred_at(&self) -> &DateTime<Utc> {
-    match self {
-      UserAccountEvent::Created { occurred_at, .. } => occurred_at,
-      UserAccountEvent::Renamed { occurred_at, .. } => occurred_at,
-    }
-  }
-
-  fn is_created(&self) -> bool {
-    match self {
-      UserAccountEvent::Created { .. } => true,
-      UserAccountEvent::Renamed { .. } => false,
-    }
-  }
-}
-
+/// Aggregate payload: pure domain state only — no seq_nr, no version, no last_updated_at.
+/// The snapshot envelope carries seq_nr / version (FR2.1 / FR3.2).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UserAccount {
   id: UserAccountId,
   name: String,
-  seq_nr: usize,
-  version: usize,
-  last_updated_at: DateTime<Utc>,
 }
 
 impl UserAccount {
   pub fn new(id: UserAccountId, name: String) -> (Self, UserAccountEvent) {
-    let mut my_self = Self {
-      id: id.clone(),
-      name,
-      seq_nr: 0,
-      version: 1,
-      last_updated_at: chrono::Utc::now(),
-    };
-    my_self.seq_nr += 1;
-    let event = UserAccountEvent::Created {
-      id: id_generate(),
-      aggregate_id: id,
-      seq_nr: my_self.seq_nr,
-      name: my_self.name.clone(),
-      occurred_at: chrono::Utc::now(),
-    };
-    (my_self, event)
+    let my_self = Self { id, name: name.clone() };
+    (my_self, UserAccountEvent::Created { name })
   }
 
   pub fn replay(events: impl IntoIterator<Item = UserAccountEvent>, snapshot: UserAccount) -> Self {
     events.into_iter().fold(snapshot, |mut result, event| {
-      result.apply_event(event.clone());
+      result.apply_event(&event);
       result
     })
   }
 
-  fn apply_event(&mut self, event: UserAccountEvent) {
-    if let UserAccountEvent::Renamed { name, .. } = event {
-      self.rename(&name).unwrap();
+  fn apply_event(&mut self, event: &UserAccountEvent) {
+    if let UserAccountEvent::Renamed { name } = event {
+      self.name = name.clone();
     }
   }
 
@@ -152,38 +95,6 @@ impl UserAccount {
       return Err(UserAccountError::AlreadyRenamed(name.to_string()));
     }
     self.name = name.to_string();
-    self.seq_nr += 1;
-    let event = UserAccountEvent::Renamed {
-      id: id_generate(),
-      aggregate_id: self.id.clone(),
-      seq_nr: self.seq_nr,
-      name: name.to_string(),
-      occurred_at: Utc::now(),
-    };
-    Ok(event)
-  }
-}
-
-impl Aggregate for UserAccount {
-  type ID = UserAccountId;
-
-  fn id(&self) -> &Self::ID {
-    &self.id
-  }
-
-  fn seq_nr(&self) -> usize {
-    self.seq_nr
-  }
-
-  fn version(&self) -> usize {
-    self.version
-  }
-
-  fn set_version(&mut self, version: usize) {
-    self.version = version
-  }
-
-  fn last_updated_at(&self) -> &DateTime<Utc> {
-    &self.last_updated_at
+    Ok(UserAccountEvent::Renamed { name: name.to_string() })
   }
 }

--- a/examples/user-account-sqlite/src/user_account_repository.rs
+++ b/examples/user-account-sqlite/src/user_account_repository.rs
@@ -1,6 +1,11 @@
 use crate::user_account::{UserAccount, UserAccountEvent, UserAccountId};
-use event_store_adapter_rs::types::{Aggregate, EventStore, EventStoreReadError, EventStoreWriteError};
+use event_store_adapter_rs::event_envelope::EventEnvelope;
+use event_store_adapter_rs::types::{EventStore, EventStoreReadError, EventStoreWriteError};
 use event_store_adapter_rs::EventStoreForSqlite;
+
+// FR8.4 / FR2.2 / FR5.1: v3 repository. Writes hand envelopes to the store together with an
+// explicit expected_version; reads recover the replay position (seq_nr) and the optimistic-lock
+// version from the envelopes instead of aggregate fields (BR2.5 — no set_version write-back).
 
 pub struct UserAccountRepository {
   event_store: EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent>,
@@ -9,7 +14,19 @@ pub struct UserAccountRepository {
 #[derive(Debug)]
 pub enum RepositoryError {
   OptimisticLockError(#[allow(dead_code)] String),
+  ContractViolation(#[allow(dead_code)] String),
   IOError(#[allow(dead_code)] String),
+}
+
+/// Read result restored from the latest snapshot plus the differential replay.
+///
+/// `seq_nr` numbers the next event as `seq_nr + 1`; `version` is the expected_version
+/// for the next write (FR2.2).
+#[derive(Debug)]
+pub struct ReplayedUserAccount {
+  pub state: UserAccount,
+  pub seq_nr: usize,
+  pub version: usize,
 }
 
 impl UserAccountRepository {
@@ -17,8 +34,12 @@ impl UserAccountRepository {
     Self { event_store }
   }
 
-  pub async fn store_event(&mut self, event: &UserAccountEvent, version: usize) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event(event, version).await;
+  pub async fn store_event(
+    &mut self,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    expected_version: usize,
+  ) -> Result<(), RepositoryError> {
+    let result = self.event_store.persist_event(event, expected_version).await;
     match result {
       Ok(_) => Ok(()),
       Err(err) => Err(Self::handle_event_store_write_error(err)),
@@ -27,39 +48,48 @@ impl UserAccountRepository {
 
   pub async fn store_event_and_snapshot(
     &mut self,
-    event: &UserAccountEvent,
-    snapshot: &UserAccount,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    snapshot: UserAccount,
+    expected_version: usize,
   ) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event_and_snapshot(event, snapshot).await;
+    let result = self
+      .event_store
+      .persist_event_and_snapshot(event, snapshot, expected_version)
+      .await;
     match result {
       Ok(_) => Ok(()),
       Err(err) => Err(Self::handle_event_store_write_error(err)),
     }
   }
 
-  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<UserAccount>, RepositoryError> {
-    let snapshot_result = self.event_store.get_latest_snapshot_by_id(id).await;
-    match snapshot_result {
-      Ok(snapshot_opt) => match snapshot_opt {
-        Some(snapshot) => {
-          let events = self
-            .event_store
-            .get_events_by_id_since_seq_nr(id, snapshot.seq_nr() + 1)
-            .await;
-          match events {
-            Ok(events) => Ok(Some(UserAccount::replay(events, snapshot))),
-            Err(err) => Err(Self::handle_event_store_read_error(err)),
-          }
-        }
-        None => Ok(None),
-      },
-      Err(err) => Err(Self::handle_event_store_read_error(err)),
-    }
+  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<ReplayedUserAccount>, RepositoryError> {
+    let snapshot = match self.event_store.get_latest_snapshot_by_id(id).await {
+      Ok(Some(snapshot)) => snapshot,
+      Ok(None) => return Ok(None),
+      Err(err) => return Err(Self::handle_event_store_read_error(err)),
+    };
+    let snapshot_seq_nr = snapshot.seq_nr();
+    let version = snapshot.version();
+    let events = match self
+      .event_store
+      .get_events_by_id_since_seq_nr(id, snapshot_seq_nr + 1)
+      .await
+    {
+      Ok(events) => events,
+      Err(err) => return Err(Self::handle_event_store_read_error(err)),
+    };
+    let seq_nr = events.last().map(|event| event.seq_nr()).unwrap_or(snapshot_seq_nr);
+    let state = UserAccount::replay(
+      events.into_iter().map(EventEnvelope::into_payload),
+      snapshot.into_aggregate(),
+    );
+    Ok(Some(ReplayedUserAccount { state, seq_nr, version }))
   }
 
   fn handle_event_store_write_error(err: EventStoreWriteError) -> RepositoryError {
     match err {
       EventStoreWriteError::OptimisticLockError(e) => RepositoryError::OptimisticLockError(e.to_string()),
+      EventStoreWriteError::ContractViolation(e) => RepositoryError::ContractViolation(e.to_string()),
       EventStoreWriteError::SerializationError(e) => RepositoryError::IOError(e.to_string()),
       EventStoreWriteError::IOError(e) => RepositoryError::IOError(e.to_string()),
       EventStoreWriteError::OtherError(e) => RepositoryError::IOError(e.to_string()),

--- a/examples/user-account/src/main.rs
+++ b/examples/user-account/src/main.rs
@@ -2,17 +2,22 @@ use std::env;
 use std::thread::sleep;
 use std::time::Duration;
 
-use event_store_adapter_rs::types::Aggregate;
+use chrono::Utc;
+use event_store_adapter_rs::event_envelope::EventEnvelope;
 use event_store_adapter_rs::EventStoreForDynamoDB;
 use event_store_adapter_test_utils_rs::docker::dynamodb_local;
 use event_store_adapter_test_utils_rs::dynamodb::{create_client, create_journal_table, create_snapshot_table};
 use event_store_adapter_test_utils_rs::id_generator::id_generate;
 
-use crate::user_account::{UserAccount, UserAccountId};
+use crate::user_account::{UserAccount, UserAccountId, CREATED_MANIFEST, RENAMED_MANIFEST};
 use crate::user_account_repository::{RepositoryError, UserAccountRepository};
 
 mod user_account;
 mod user_account_repository;
+
+// FR8.4: v3 envelope-API walkthrough. Creation persists a seq_nr=1 envelope with
+// expected_version=0; updates number the next envelope from the replayed seq_nr and pass the
+// replayed version as expected_version (BR2.3 / BR2.6).
 
 #[tokio::main]
 async fn main() {
@@ -86,10 +91,10 @@ async fn create_user_account(
   name: &str,
 ) -> Result<UserAccountId, RepositoryError> {
   let user_account_id = UserAccountId::new(id.to_string());
-  let (user_account, user_account_event) = UserAccount::new(user_account_id.clone(), name.to_string());
-  repository
-    .store_event_and_snapshot(&user_account_event, &user_account)
-    .await?;
+  let (user_account, created) = UserAccount::new(user_account_id.clone(), name.to_string());
+  // The first event of a stream is seq_nr == 1 and is written with expected_version == 0 (BR2.6).
+  let envelope = EventEnvelope::new(user_account_id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST);
+  repository.store_event_and_snapshot(envelope, user_account, 0).await?;
   Ok(user_account_id)
 }
 
@@ -98,9 +103,11 @@ async fn rename_user_account(
   user_account_id: &UserAccountId,
   name: &str,
 ) -> Result<(), RepositoryError> {
-  let mut user_account = repository.find_by_id(user_account_id).await?.unwrap();
-  let user_account_event = user_account.rename(name).unwrap();
-  repository
-    .store_event(&user_account_event, user_account.version())
-    .await
+  let mut replayed = repository.find_by_id(user_account_id).await?.unwrap();
+  let renamed = replayed.state.rename(name).unwrap();
+  // The domain numbers the next event as replayed seq_nr + 1 (FR3.3) and passes the replayed
+  // version as expected_version for the optimistic lock (FR2.2).
+  let envelope = EventEnvelope::new(user_account_id.clone(), replayed.seq_nr + 1, Utc::now(), renamed)
+    .with_manifest(RENAMED_MANIFEST);
+  repository.store_event(envelope, replayed.version).await
 }

--- a/examples/user-account/src/user_account.rs
+++ b/examples/user-account/src/user_account.rs
@@ -1,9 +1,15 @@
-use chrono::{DateTime, Utc};
-use event_store_adapter_rs::types::{Aggregate, AggregateId, Event};
-use event_store_adapter_test_utils_rs::id_generator::id_generate;
+use event_store_adapter_rs::types::AggregateId;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
-use ulid_generator_rs::ULID;
+
+// FR8.4 / FR3.1 / FR3.2: v3 example domain model. The `Event` / `Aggregate` traits are gone;
+// the event and the aggregate state are plain serde types (payloads), and the metadata
+// (aggregate_id / seq_nr / occurred_at / manifest) travels in the envelopes.
+
+/// Manifest value carried by the creation event envelope (FR1.2 — user-supplied, free-form).
+pub const CREATED_MANIFEST: &str = "user-account-created/v1";
+/// Manifest value carried by the rename event envelope.
+pub const RENAMED_MANIFEST: &str = "user-account-renamed/v1";
 
 #[derive(Debug)]
 pub enum UserAccountError {
@@ -37,103 +43,38 @@ impl AggregateId for UserAccountId {
   }
 }
 
+/// Event payload: pure domain content only — no event ID, no seq_nr, no timestamp.
+/// The envelope carries those (FR1.1).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum UserAccountEvent {
-  Created {
-    id: ULID,
-    aggregate_id: UserAccountId,
-    seq_nr: usize,
-    name: String,
-    occurred_at: DateTime<Utc>,
-  },
-  Renamed {
-    id: ULID,
-    aggregate_id: UserAccountId,
-    seq_nr: usize,
-    name: String,
-    occurred_at: DateTime<Utc>,
-  },
+  Created { name: String },
+  Renamed { name: String },
 }
 
-impl Event for UserAccountEvent {
-  type AggregateID = UserAccountId;
-  type ID = ULID;
-
-  fn id(&self) -> &Self::ID {
-    match self {
-      UserAccountEvent::Created { id, .. } => id,
-      UserAccountEvent::Renamed { id, .. } => id,
-    }
-  }
-
-  fn aggregate_id(&self) -> &Self::AggregateID {
-    match self {
-      UserAccountEvent::Created { aggregate_id, .. } => aggregate_id,
-      UserAccountEvent::Renamed { aggregate_id, .. } => aggregate_id,
-    }
-  }
-
-  fn seq_nr(&self) -> usize {
-    match self {
-      UserAccountEvent::Created { seq_nr, .. } => *seq_nr,
-      UserAccountEvent::Renamed { seq_nr, .. } => *seq_nr,
-    }
-  }
-
-  fn occurred_at(&self) -> &DateTime<Utc> {
-    match self {
-      UserAccountEvent::Created { occurred_at, .. } => occurred_at,
-      UserAccountEvent::Renamed { occurred_at, .. } => occurred_at,
-    }
-  }
-
-  fn is_created(&self) -> bool {
-    match self {
-      UserAccountEvent::Created { .. } => true,
-      UserAccountEvent::Renamed { .. } => false,
-    }
-  }
-}
-
+/// Aggregate payload: pure domain state only — no seq_nr, no version, no last_updated_at.
+/// The snapshot envelope carries seq_nr / version (FR2.1 / FR3.2).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UserAccount {
   id: UserAccountId,
   name: String,
-  seq_nr: usize,
-  version: usize,
-  last_updated_at: DateTime<Utc>,
 }
 
 impl UserAccount {
   pub fn new(id: UserAccountId, name: String) -> (Self, UserAccountEvent) {
-    let mut my_self = Self {
-      id: id.clone(),
-      name,
-      seq_nr: 0,
-      version: 1,
-      last_updated_at: chrono::Utc::now(),
-    };
-    my_self.seq_nr += 1;
-    let event = UserAccountEvent::Created {
-      id: id_generate(),
-      aggregate_id: id,
-      seq_nr: my_self.seq_nr,
-      name: my_self.name.clone(),
-      occurred_at: chrono::Utc::now(),
-    };
-    (my_self, event)
+    let my_self = Self { id, name: name.clone() };
+    (my_self, UserAccountEvent::Created { name })
   }
 
   pub fn replay(events: impl IntoIterator<Item = UserAccountEvent>, snapshot: UserAccount) -> Self {
     events.into_iter().fold(snapshot, |mut result, event| {
-      result.apply_event(event.clone());
+      result.apply_event(&event);
       result
     })
   }
 
-  fn apply_event(&mut self, event: UserAccountEvent) {
-    if let UserAccountEvent::Renamed { name, .. } = event {
-      self.rename(&name).unwrap();
+  fn apply_event(&mut self, event: &UserAccountEvent) {
+    if let UserAccountEvent::Renamed { name } = event {
+      self.name = name.clone();
     }
   }
 
@@ -142,38 +83,6 @@ impl UserAccount {
       return Err(UserAccountError::AlreadyRenamed(name.to_string()));
     }
     self.name = name.to_string();
-    self.seq_nr += 1;
-    let event = UserAccountEvent::Renamed {
-      id: id_generate(),
-      aggregate_id: self.id.clone(),
-      seq_nr: self.seq_nr,
-      name: name.to_string(),
-      occurred_at: Utc::now(),
-    };
-    Ok(event)
-  }
-}
-
-impl Aggregate for UserAccount {
-  type ID = UserAccountId;
-
-  fn id(&self) -> &Self::ID {
-    &self.id
-  }
-
-  fn seq_nr(&self) -> usize {
-    self.seq_nr
-  }
-
-  fn version(&self) -> usize {
-    self.version
-  }
-
-  fn set_version(&mut self, version: usize) {
-    self.version = version
-  }
-
-  fn last_updated_at(&self) -> &DateTime<Utc> {
-    &self.last_updated_at
+    Ok(UserAccountEvent::Renamed { name: name.to_string() })
   }
 }

--- a/examples/user-account/src/user_account_repository.rs
+++ b/examples/user-account/src/user_account_repository.rs
@@ -1,6 +1,11 @@
 use crate::user_account::{UserAccount, UserAccountEvent, UserAccountId};
-use event_store_adapter_rs::types::{Aggregate, EventStore, EventStoreReadError, EventStoreWriteError};
+use event_store_adapter_rs::event_envelope::EventEnvelope;
+use event_store_adapter_rs::types::{EventStore, EventStoreReadError, EventStoreWriteError};
 use event_store_adapter_rs::EventStoreForDynamoDB;
+
+// FR8.4 / FR2.2 / FR5.1: v3 repository. Writes hand envelopes to the store together with an
+// explicit expected_version; reads recover the replay position (seq_nr) and the optimistic-lock
+// version from the envelopes instead of aggregate fields (BR2.5 — no set_version write-back).
 
 pub struct UserAccountRepository {
   event_store: EventStoreForDynamoDB<UserAccountId, UserAccount, UserAccountEvent>,
@@ -9,7 +14,19 @@ pub struct UserAccountRepository {
 #[derive(Debug)]
 pub enum RepositoryError {
   OptimisticLockError(#[allow(dead_code)] String),
+  ContractViolation(#[allow(dead_code)] String),
   IOError(#[allow(dead_code)] String),
+}
+
+/// Read result restored from the latest snapshot plus the differential replay.
+///
+/// `seq_nr` numbers the next event as `seq_nr + 1`; `version` is the expected_version
+/// for the next write (FR2.2).
+#[derive(Debug)]
+pub struct ReplayedUserAccount {
+  pub state: UserAccount,
+  pub seq_nr: usize,
+  pub version: usize,
 }
 
 impl UserAccountRepository {
@@ -17,8 +34,12 @@ impl UserAccountRepository {
     Self { event_store }
   }
 
-  pub async fn store_event(&mut self, event: &UserAccountEvent, version: usize) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event(event, version).await;
+  pub async fn store_event(
+    &mut self,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    expected_version: usize,
+  ) -> Result<(), RepositoryError> {
+    let result = self.event_store.persist_event(event, expected_version).await;
     match result {
       Ok(_) => Ok(()),
       Err(err) => Err(Self::handle_event_store_write_error(err)),
@@ -27,39 +48,48 @@ impl UserAccountRepository {
 
   pub async fn store_event_and_snapshot(
     &mut self,
-    event: &UserAccountEvent,
-    snapshot: &UserAccount,
+    event: EventEnvelope<UserAccountId, UserAccountEvent>,
+    snapshot: UserAccount,
+    expected_version: usize,
   ) -> Result<(), RepositoryError> {
-    let result = self.event_store.persist_event_and_snapshot(event, snapshot).await;
+    let result = self
+      .event_store
+      .persist_event_and_snapshot(event, snapshot, expected_version)
+      .await;
     match result {
       Ok(_) => Ok(()),
       Err(err) => Err(Self::handle_event_store_write_error(err)),
     }
   }
 
-  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<UserAccount>, RepositoryError> {
-    let snapshot_result = self.event_store.get_latest_snapshot_by_id(id).await;
-    match snapshot_result {
-      Ok(snapshot_opt) => match snapshot_opt {
-        Some(snapshot) => {
-          let events = self
-            .event_store
-            .get_events_by_id_since_seq_nr(id, snapshot.seq_nr() + 1)
-            .await;
-          match events {
-            Ok(events) => Ok(Some(UserAccount::replay(events, snapshot))),
-            Err(err) => Err(Self::handle_event_store_read_error(err)),
-          }
-        }
-        None => Ok(None),
-      },
-      Err(err) => Err(Self::handle_event_store_read_error(err)),
-    }
+  pub async fn find_by_id(&self, id: &UserAccountId) -> Result<Option<ReplayedUserAccount>, RepositoryError> {
+    let snapshot = match self.event_store.get_latest_snapshot_by_id(id).await {
+      Ok(Some(snapshot)) => snapshot,
+      Ok(None) => return Ok(None),
+      Err(err) => return Err(Self::handle_event_store_read_error(err)),
+    };
+    let snapshot_seq_nr = snapshot.seq_nr();
+    let version = snapshot.version();
+    let events = match self
+      .event_store
+      .get_events_by_id_since_seq_nr(id, snapshot_seq_nr + 1)
+      .await
+    {
+      Ok(events) => events,
+      Err(err) => return Err(Self::handle_event_store_read_error(err)),
+    };
+    let seq_nr = events.last().map(|event| event.seq_nr()).unwrap_or(snapshot_seq_nr);
+    let state = UserAccount::replay(
+      events.into_iter().map(EventEnvelope::into_payload),
+      snapshot.into_aggregate(),
+    );
+    Ok(Some(ReplayedUserAccount { state, seq_nr, version }))
   }
 
   fn handle_event_store_write_error(err: EventStoreWriteError) -> RepositoryError {
     match err {
       EventStoreWriteError::OptimisticLockError(e) => RepositoryError::OptimisticLockError(e.to_string()),
+      EventStoreWriteError::ContractViolation(e) => RepositoryError::ContractViolation(e.to_string()),
       EventStoreWriteError::SerializationError(e) => RepositoryError::IOError(e.to_string()),
       EventStoreWriteError::IOError(e) => RepositoryError::IOError(e.to_string()),
       EventStoreWriteError::OtherError(e) => RepositoryError::IOError(e.to_string()),

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,6 +6,10 @@ description = "Event Store adapter for CQRS/Event Sourcing with DynamoDB, Bigtab
 authors = ["Junichi Kato <j5ik2o@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
+# FR8.3: MSRV measured with `cargo build -p event-store-adapter-rs --all-features` on
+# 2026-08-28 - the AWS SDK crates (aws-config / aws-sdk-dynamodb and their smithy stack)
+# require rustc 1.94.1; 1.94.0 and below fail to resolve. Re-measure when bumping them.
+rust-version = "1.94.1"
 keywords = ["event-sourcing", "cqrs", "ddd"]
 categories = ["data-structures", "web-programming", "rust-patterns"]
 readme = "../README.md"

--- a/lib/src/event_envelope.rs
+++ b/lib/src/event_envelope.rs
@@ -1,0 +1,147 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// FR1.1-1.4 / FR2.1: journal / snapshot に対応する封筒型。メタデータと payload を分離して運搬する。
+// ADR-009: 構造体定義に trait 境界を置かない（derive は条件付き実装のみを生成し、構築時の要求を増やさない）。
+
+/// ジャーナル 1 行に対応するイベント封筒を表す。
+///
+/// メタデータ 4 点（aggregate_id / seq_nr / occurred_at / manifest）と純ドメイン内容の
+/// payload を運搬する。ライブラリは封筒を透過運搬するだけで、値を解釈しない。
+///
+/// # seq_nr 契約（FR3.3 / FR3.4 / BR6.1）
+///
+/// - seq_nr は 1 始まりで、同一ストリーム内で連続していることを利用者（ドメイン側）が保証する
+/// - 採番はドメイン側の責務であり、ストアは採番しない。封筒の seq_nr がそのまま保存される
+/// - ライブラリは連続性を検証しない。重複は楽観ロック（CAS / 一意制約）が拒否し、
+///   飛び番は検出されずそのまま書き込まれる（利用者責務）
+/// - seq_nr == 0 の封筒は書込時に `EventStoreWriteError::ContractViolation` で拒否される（BR1.4）
+///
+/// # 拡張（FR1.3 / BR1.5）
+///
+/// フィールドは非公開で、読取はアクセサ、構築は [`EventEnvelope::new`] +
+/// `with_*` ビルダーに限定する。将来のフィールド追加は既定値付きの `with_*` を
+/// 増やす形で行えるため、既存利用コードを壊さない（非破壊拡張）。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventEnvelope<AID, P> {
+  aggregate_id: AID,
+  seq_nr: usize,
+  occurred_at: DateTime<Utc>,
+  manifest: String,
+  payload: P,
+}
+
+impl<AID, P> EventEnvelope<AID, P> {
+  /// イベント封筒を構築する。
+  ///
+  /// BR1.1: 必須メタデータ（aggregate_id / seq_nr / occurred_at）と payload は
+  /// 引数として強制され、欠落はコンパイル不能。manifest のみ省略可能で、
+  /// 省略時は空文字列となる（FR1.2）。
+  pub fn new(aggregate_id: AID, seq_nr: usize, occurred_at: DateTime<Utc>, payload: P) -> Self {
+    Self {
+      aggregate_id,
+      seq_nr,
+      occurred_at,
+      manifest: String::new(),
+      payload,
+    }
+  }
+
+  /// manifest を設定した封筒を返す。
+  ///
+  /// BR1.2 / FR1.2: manifest は利用者供給・自由形式であり、ライブラリは値を解釈せず
+  /// 運搬のみを行う（保存した値が読出しで同値のまま返る）。
+  pub fn with_manifest(mut self, manifest: impl Into<String>) -> Self {
+    self.manifest = manifest.into();
+    self
+  }
+
+  /// 集約 ID を返す。
+  pub fn aggregate_id(&self) -> &AID {
+    &self.aggregate_id
+  }
+
+  /// シーケンス番号（1 始まり・ドメイン採番）を返す。
+  pub fn seq_nr(&self) -> usize {
+    self.seq_nr
+  }
+
+  /// ドメイン供給の発生時刻を返す。
+  ///
+  /// BR1.3 / FR1.4: この値はストア刻印に置換されず、保存・読出しの全経路で
+  /// 供給値のまま維持される。
+  pub fn occurred_at(&self) -> &DateTime<Utc> {
+    &self.occurred_at
+  }
+
+  /// manifest を返す（未指定の場合は空文字列）。
+  pub fn manifest(&self) -> &str {
+    &self.manifest
+  }
+
+  /// payload への参照を返す。
+  pub fn payload(&self) -> &P {
+    &self.payload
+  }
+
+  /// 封筒を消費して payload の所有権を返す。
+  ///
+  /// payload が `Clone` を実装しない型でもリプレイ（W4）で畳み込めるようにする
+  /// 所有権移動のアクセサ（BR1.6 の最小境界を崩さないための出口）。
+  pub fn into_payload(self) -> P {
+    self.payload
+  }
+}
+
+/// スナップショット 1 件に対応する封筒を表す。
+///
+/// 集約の純ドメイン状態（aggregate）と、反映済みイベント位置（seq_nr）・
+/// 楽観ロック版数（version）を運搬する。FR2.1: 旧 `event_store_backend` の
+/// 内部型からの公開昇格。FR2.2 / BR3.1: 読取 API はこの封筒を返し、
+/// seq_nr / version を境界で破棄しない。
+///
+/// version の正は常にストレージ列側にあり、読取時に payload から補正されない
+/// （BR2.5 / FR4.3）。利用者は `seq_nr()` をリプレイ開始点、`version()` を
+/// 次回書込の expected_version として使う（W4）。
+#[derive(Debug, Clone, PartialEq)]
+pub struct SnapshotEnvelope<A> {
+  aggregate: A,
+  seq_nr: usize,
+  version: usize,
+}
+
+impl<A> SnapshotEnvelope<A> {
+  /// スナップショット封筒を構築する。
+  ///
+  /// BR1.5: フィールドは非公開のため、将来のフィールド追加は非破壊で行える。
+  pub fn new(aggregate: A, seq_nr: usize, version: usize) -> Self {
+    Self {
+      aggregate,
+      seq_nr,
+      version,
+    }
+  }
+
+  /// 集約の純ドメイン状態への参照を返す。
+  pub fn aggregate(&self) -> &A {
+    &self.aggregate
+  }
+
+  /// このスナップショットが反映済みのイベント封筒の seq_nr を返す（リプレイ開始点）。
+  pub fn seq_nr(&self) -> usize {
+    self.seq_nr
+  }
+
+  /// 楽観ロックの版数を返す（1 始まり。正は列側 — BR2.5）。
+  pub fn version(&self) -> usize {
+    self.version
+  }
+
+  /// 封筒を消費して集約状態の所有権を返す。
+  ///
+  /// 集約状態が `Clone` を実装しない型でもリプレイの初期値に使えるようにする
+  /// 所有権移動のアクセサ。
+  pub fn into_aggregate(self) -> A {
+    self.aggregate
+  }
+}

--- a/lib/src/event_envelope_test.rs
+++ b/lib/src/event_envelope_test.rs
@@ -1,0 +1,183 @@
+use chrono::{DateTime, TimeZone, Utc};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
+use crate::types::AggregateId;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct TestId(String);
+
+impl Display for TestId {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.0)
+  }
+}
+
+impl AggregateId for TestId {
+  fn type_name(&self) -> String {
+    "TestAggregate".to_string()
+  }
+
+  fn value(&self) -> String {
+    self.0.clone()
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct TestPayload {
+  name: String,
+}
+
+fn fixed_occurred_at() -> DateTime<Utc> {
+  Utc.with_ymd_and_hms(2026, 8, 27, 12, 34, 56).unwrap()
+}
+
+// AC1.1.2 / US1.1: 封筒構築とアクセサの読取（メタデータ 4 点 + payload の運搬）
+#[test]
+fn test_event_envelope_construction_and_accessors() {
+  let occurred_at = fixed_occurred_at();
+  let envelope = EventEnvelope::new(
+    TestId("a-1".to_string()),
+    1,
+    occurred_at,
+    TestPayload {
+      name: "created".to_string(),
+    },
+  );
+
+  assert_eq!(envelope.aggregate_id(), &TestId("a-1".to_string()));
+  assert_eq!(envelope.seq_nr(), 1);
+  // BR1.3: occurred_at はドメイン供給値のまま維持される
+  assert_eq!(envelope.occurred_at(), &occurred_at);
+  assert_eq!(envelope.payload().name, "created");
+}
+
+// BR1.1 / FR1.2: manifest 省略時は空文字列
+#[test]
+fn test_event_envelope_manifest_defaults_to_empty_string() {
+  let envelope = EventEnvelope::new(
+    TestId("a-1".to_string()),
+    1,
+    fixed_occurred_at(),
+    TestPayload {
+      name: "created".to_string(),
+    },
+  );
+  assert_eq!(envelope.manifest(), "");
+}
+
+// BR1.2: with_manifest で設定した値が同値で読み取れる（ライブラリは値を解釈しない）
+#[test]
+fn test_event_envelope_with_manifest_carries_value_verbatim() {
+  let envelope = EventEnvelope::new(
+    TestId("a-1".to_string()),
+    2,
+    fixed_occurred_at(),
+    TestPayload {
+      name: "renamed".to_string(),
+    },
+  )
+  .with_manifest("com.example.UserAccountEvent.Renamed#v2");
+  assert_eq!(envelope.manifest(), "com.example.UserAccountEvent.Renamed#v2");
+}
+
+// FR7.4 / AC1.2.1: manifest ラウンドトリップ — serde 往復で封筒全体が同値
+#[test]
+fn test_event_envelope_manifest_serde_round_trip() {
+  let envelope = EventEnvelope::new(
+    TestId("a-1".to_string()),
+    3,
+    fixed_occurred_at(),
+    TestPayload {
+      name: "renamed".to_string(),
+    },
+  )
+  .with_manifest("manifest-v1");
+
+  let json = serde_json::to_string(&envelope).unwrap();
+  let restored: EventEnvelope<TestId, TestPayload> = serde_json::from_str(&json).unwrap();
+  assert_eq!(restored, envelope);
+  assert_eq!(restored.manifest(), "manifest-v1");
+}
+
+// FR7.4 / FR1.2: 省略時の空文字列 manifest も同値でラウンドトリップする
+#[test]
+fn test_event_envelope_default_manifest_serde_round_trip() {
+  let envelope = EventEnvelope::new(
+    TestId("a-1".to_string()),
+    1,
+    fixed_occurred_at(),
+    TestPayload {
+      name: "created".to_string(),
+    },
+  );
+
+  let json = serde_json::to_string(&envelope).unwrap();
+  let restored: EventEnvelope<TestId, TestPayload> = serde_json::from_str(&json).unwrap();
+  assert_eq!(restored, envelope);
+  assert_eq!(restored.manifest(), "");
+}
+
+// FR2.1: SnapshotEnvelope の構築とアクセサ（公開昇格した封筒の形状）
+#[test]
+fn test_snapshot_envelope_construction_and_accessors() {
+  let snapshot = SnapshotEnvelope::new(
+    TestPayload {
+      name: "current".to_string(),
+    },
+    2,
+    5,
+  );
+  assert_eq!(snapshot.aggregate().name, "current");
+  assert_eq!(snapshot.seq_nr(), 2);
+  assert_eq!(snapshot.version(), 5);
+  assert_eq!(snapshot.into_aggregate().name, "current");
+}
+
+// FR7.3 ① / AC1.1.1 / NFR2: 型レベル検証 — derive(Serialize, Deserialize) のみの
+// プレーン型（Debug / Clone なし）が payload 最小境界を満たし、封筒を構築できる
+#[test]
+fn test_plain_serde_type_satisfies_minimal_payload_bound() {
+  // Debug / Clone を持たないプレーン型（ライブラリ trait 非実装）
+  #[derive(Serialize, Deserialize)]
+  struct PlainPayload {
+    value: String,
+  }
+
+  #[derive(Serialize, Deserialize)]
+  struct PlainAggregate {
+    value: String,
+  }
+
+  // payload 最小境界（Serialize + DeserializeOwned + Send + Sync + 'static — BR1.6）を
+  // 満たすことのコンパイル検証
+  fn assert_minimal_payload_bound<T: Serialize + DeserializeOwned + Send + Sync + 'static>() {}
+  assert_minimal_payload_bound::<PlainPayload>();
+  assert_minimal_payload_bound::<PlainAggregate>();
+
+  let envelope = EventEnvelope::new(
+    TestId("a-1".to_string()),
+    1,
+    fixed_occurred_at(),
+    PlainPayload {
+      value: "plain".to_string(),
+    },
+  )
+  .with_manifest("plain-v1");
+  assert_eq!(envelope.seq_nr(), 1);
+  assert_eq!(envelope.manifest(), "plain-v1");
+  assert_eq!(envelope.payload().value, "plain");
+  assert_eq!(envelope.into_payload().value, "plain");
+
+  let snapshot = SnapshotEnvelope::new(
+    PlainAggregate {
+      value: "plain".to_string(),
+    },
+    1,
+    1,
+  );
+  assert_eq!(snapshot.aggregate().value, "plain");
+  assert_eq!(snapshot.into_aggregate().value, "plain");
+}

--- a/lib/src/event_store_backend.rs
+++ b/lib/src/event_store_backend.rs
@@ -1,47 +1,69 @@
 use std::fmt::Debug;
 
-use crate::types::{Aggregate, AggregateId, Event, EventStoreReadError, EventStoreWriteError};
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
+use crate::types::{EventStoreReadError, EventStoreWriteError};
 use async_trait::async_trait;
 use chrono::Duration;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct SnapshotEnvelope<A> {
-  pub aggregate: A,
-  pub seq_nr: usize,
-  pub version: usize,
-}
+// FR4.1 / FR5.1 / C2: 非公開 SPI。GenericEventStore と各バックエンドの境界を封筒
+// （EventEnvelope / SnapshotEnvelope）の受け渡しに統一する。SnapshotEnvelope は v3 で
+// `event_envelope` モジュールへ移設・公開昇格した（FR2.1）。
 
+/// 保持ポリシー設定の値オブジェクト（SPI 運搬用）。
+///
+/// BR4.1: 有効値は `keep_snapshot_count = None`（剪定しない）と `Some(n >= 1)`
+/// （履歴 n 件保持）のみ。`Some(0)` はビルダーで拒否されるため、ここには到達しない。
+/// `delete_ttl` は `keep_snapshot_count` と併用時のみ効果を持つ（現行契約維持）。
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SnapshotMaintenance {
   pub keep_snapshot_count: Option<usize>,
   pub delete_ttl: Option<Duration>,
 }
 
+/// ストレージバックエンドの SPI を表すトレイト（非公開 mod — semver 制約なし）。
+///
+/// 型パラメータへの境界は最小に留める（BR1.6 — payload への Debug / Clone 要求を
+/// 作らない）。`AID: Sync` のみ、`on_event_persisted` の既定実装が `&AID` を
+/// Send な Future に保持するために要求する。
 #[async_trait]
-pub trait StorageBackend<AID, A, E>: Send + Sync + Clone + Debug + 'static
+pub trait StorageBackend<AID, A, P>: Send + Sync + Clone + Debug + 'static
 where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
+  AID: Sync, {
+  /// 最新のスナップショット封筒を取得する。存在しなければ `None` を返す（BR3.1）。
   async fn fetch_latest_snapshot(&self, aid: &AID) -> Result<Option<SnapshotEnvelope<A>>, EventStoreReadError>;
 
-  async fn fetch_events_since(&self, aid: &AID, seq_nr: usize) -> Result<Vec<E>, EventStoreReadError>;
+  /// 指定 seq_nr 以降のイベント封筒列を返す（裸の payload 列は返さない — FR5.1 / BR3.2）。
+  async fn fetch_events_since(
+    &self,
+    aid: &AID,
+    seq_nr: usize,
+  ) -> Result<Vec<EventEnvelope<AID, P>>, EventStoreReadError>;
 
+  /// 新規集約の journal + snapshot を原子的に作成する（W1）。
+  ///
+  /// snapshot は version = 1、seq_nr = `event.seq_nr()` で作成する。既存集約が
+  /// 存在する場合は `OptimisticLockError` を返す（一意制約 / 条件付き書込）。
   async fn create_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: &A,
     maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError>;
 
+  /// 既存集約の更新を version CAS で原子的に書く（W2 / W3）。
+  ///
+  /// BR2.3: 格納中の version と `expected_version` を照合し、競合時は
+  /// `OptimisticLockError`、成功時は version = expected + 1 とする（version 加算は列側）。
+  /// `aggregate = None` はイベントのみ更新（`persist_event` 経路）。
   async fn update_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: Option<&A>,
     expected_version: usize,
     maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError>;
 
+  /// 書込成功後のフック（保持ポリシー実行 — BR4.2）。既定は no-op。
   async fn on_event_persisted(
     &self,
     _aid: &AID,

--- a/lib/src/event_store_for_bigtable.rs
+++ b/lib/src/event_store_for_bigtable.rs
@@ -1,43 +1,76 @@
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::bigtable_client::BigtableClient;
 use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::read_rows_response::cell_chunk::RowStatus;
 use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::read_rows_response::CellChunk;
 use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::{
   mutation, row_filter,
   row_range::{EndKey, StartKey},
-  MutateRowRequest, Mutation, ReadRowsRequest, RowFilter, RowRange, RowSet,
+  value_range::{EndValue, StartValue},
+  CheckAndMutateRowRequest, MutateRowRequest, Mutation, ReadRowsRequest, RowFilter, RowRange, RowSet, ValueRange,
 };
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tonic::transport::Channel;
 use tonic::Status;
 
-use crate::event_store_backend::{SnapshotEnvelope, SnapshotMaintenance, StorageBackend};
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
+use crate::event_store_backend::{SnapshotMaintenance, StorageBackend};
 use crate::generic_event_store::GenericEventStore;
 use crate::key_resolver::{DefaultKeyResolver, KeyResolver};
 use crate::serializer::{EventSerializer, SnapshotSerializer};
 use crate::types::{
-  format_optimistic_lock_message, Aggregate, AggregateId, Event, EventStore, EventStoreReadError, EventStoreWriteError,
+  format_optimistic_lock_message, AggregateId, EventStore, EventStoreReadError, EventStoreWriteError,
 };
+
+// FR6.1 / FR6.2 / FR6.3: Bigtable バックエンドの v3 封筒化。封筒⇔セルの 1:1 マッピング
+// （AC2.1.1 — 1 封筒 = journal 1 行）、CheckAndMutateRow による原子的 CAS（BR1.1 / BR1.2）、
+// 履歴行 + 剪定フックによる保持ポリシー（BR3.1）を StorageBackend + GenericEventStore の
+// 2 層委譲構造の上に実装する。
 
 const EVENT_FAMILY: &str = "event";
 const SNAPSHOT_FAMILY: &str = "snapshot";
 
-#[derive(Clone, Debug)]
-pub struct EventStoreForBigtable<AID, A, E>
+const QUALIFIER_PAYLOAD: &[u8] = b"payload";
+const QUALIFIER_AGGREGATE_ID: &[u8] = b"aggregate_id";
+const QUALIFIER_SEQ_NR: &[u8] = b"seq_nr";
+const QUALIFIER_OCCURRED_AT: &[u8] = b"occurred_at";
+const QUALIFIER_MANIFEST: &[u8] = b"manifest";
+const QUALIFIER_VERSION: &[u8] = b"version";
+const QUALIFIER_LAST_UPDATED_AT: &[u8] = b"last_updated_at";
+
+/// Event Store for Google Cloud Bigtable
+pub struct EventStoreForBigtable<AID, A, P>
 where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
-  inner: GenericEventStore<AID, A, E, BigtableBackend<AID, A, E>>,
+  AID: AggregateId, {
+  inner: GenericEventStore<AID, A, P, BigtableBackend<AID, A, P>>,
 }
 
-impl<AID, A, E> EventStoreForBigtable<AID, A, E>
+// P2(U1): derive は型パラメータ（A / P）へ Debug / Clone 境界を課すため手動 impl とし、
+// payload への要求を実フィールド由来のものに限定する（BR1.6 の最小境界維持）
+impl<AID: AggregateId, A, P> Debug for EventStoreForBigtable<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("EventStoreForBigtable").finish()
+  }
+}
+
+impl<AID: AggregateId, A, P> Clone for EventStoreForBigtable<AID, A, P> {
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+    }
+  }
+}
+
+impl<AID, A, P> EventStoreForBigtable<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   pub fn new(
     client: BigtableClient<Channel>,
@@ -65,7 +98,7 @@ where
     self
   }
 
-  pub fn with_event_serializer(mut self, serializer: Arc<dyn EventSerializer<E>>) -> Self {
+  pub fn with_event_serializer(mut self, serializer: Arc<dyn EventSerializer<P>>) -> Self {
     self.inner.backend_mut().set_event_serializer(serializer);
     self
   }
@@ -75,8 +108,20 @@ where
     self
   }
 
-  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Self {
-    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count);
+  /// 保持するスナップショット履歴数を設定する。
+  ///
+  /// BR4.1 / P3: 検証（`Some(0)` の拒否）は `GenericEventStore` 側の 1 箇所で行い、
+  /// このラッパーは Result を素通しする。
+  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Result<Self, EventStoreWriteError> {
+    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count)?;
+    Ok(self)
+  }
+
+  /// 履歴スナップショットの保持期限を設定する。
+  ///
+  /// `with_keep_snapshot_count` と併用時のみ効果を持つ（`SnapshotMaintenance` の現行契約）。
+  pub fn with_delete_ttl(mut self, delete_ttl: Option<Duration>) -> Self {
+    self.inner = self.inner.with_delete_ttl(delete_ttl);
     self
   }
 
@@ -86,29 +131,40 @@ where
 }
 
 #[async_trait]
-impl<AID, A, E> EventStore for EventStoreForBigtable<AID, A, E>
+impl<AID, A, P> EventStore for EventStoreForBigtable<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
-  type AG = A;
+  type A = A;
   type AID = AID;
-  type EV = E;
+  type P = P;
 
-  async fn persist_event(&mut self, event: &Self::EV, version: usize) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event(event, version).await
+  async fn persist_event(
+    &mut self,
+    event: EventEnvelope<Self::AID, Self::P>,
+    expected_version: usize,
+  ) -> Result<(), EventStoreWriteError> {
+    self.inner.persist_event(event, expected_version).await
   }
 
   async fn persist_event_and_snapshot(
     &mut self,
-    event: &Self::EV,
-    aggregate: &Self::AG,
+    event: EventEnvelope<Self::AID, Self::P>,
+    aggregate: Self::A,
+    expected_version: usize,
   ) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event_and_snapshot(event, aggregate).await
+    self
+      .inner
+      .persist_event_and_snapshot(event, aggregate, expected_version)
+      .await
   }
 
-  async fn get_latest_snapshot_by_id(&self, aid: &Self::AID) -> Result<Option<Self::AG>, EventStoreReadError> {
+  async fn get_latest_snapshot_by_id(
+    &self,
+    aid: &Self::AID,
+  ) -> Result<Option<SnapshotEnvelope<Self::A>>, EventStoreReadError> {
     self.inner.get_latest_snapshot_by_id(aid).await
   }
 
@@ -116,17 +172,14 @@ where
     &self,
     aid: &Self::AID,
     seq_nr: usize,
-  ) -> Result<Vec<Self::EV>, EventStoreReadError> {
+  ) -> Result<Vec<EventEnvelope<Self::AID, Self::P>>, EventStoreReadError> {
     self.inner.get_events_by_id_since_seq_nr(aid, seq_nr).await
   }
 }
 
-#[derive(Clone, Debug)]
-struct BigtableBackend<AID, A, E>
+struct BigtableBackend<AID, A, P>
 where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
+  AID: AggregateId, {
   client: BigtableClient<Channel>,
   project_id: String,
   instance_id: String,
@@ -134,15 +187,38 @@ where
   snapshot_table_name: String,
   shard_count: u64,
   key_resolver: Arc<dyn KeyResolver<ID = AID>>,
-  event_serializer: Arc<dyn EventSerializer<E>>,
+  event_serializer: Arc<dyn EventSerializer<P>>,
   snapshot_serializer: Arc<dyn SnapshotSerializer<A>>,
 }
 
-impl<AID, A, E> BigtableBackend<AID, A, E>
+// P2(U1): derive は A / P へ Debug 境界を課すため手動 impl とする（内部構成は表示しない）
+impl<AID: AggregateId, A, P> Debug for BigtableBackend<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("BigtableBackend").finish()
+  }
+}
+
+impl<AID: AggregateId, A, P> Clone for BigtableBackend<AID, A, P> {
+  fn clone(&self) -> Self {
+    Self {
+      client: self.client.clone(),
+      project_id: self.project_id.clone(),
+      instance_id: self.instance_id.clone(),
+      journal_table_name: self.journal_table_name.clone(),
+      snapshot_table_name: self.snapshot_table_name.clone(),
+      shard_count: self.shard_count,
+      key_resolver: Arc::clone(&self.key_resolver),
+      event_serializer: Arc::clone(&self.event_serializer),
+      snapshot_serializer: Arc::clone(&self.snapshot_serializer),
+    }
+  }
+}
+
+impl<AID, A, P> BigtableBackend<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   fn new(
     client: BigtableClient<Channel>,
@@ -169,7 +245,7 @@ where
     self.key_resolver = key_resolver;
   }
 
-  fn set_event_serializer(&mut self, serializer: Arc<dyn EventSerializer<E>>) {
+  fn set_event_serializer(&mut self, serializer: Arc<dyn EventSerializer<P>>) {
     self.event_serializer = serializer;
   }
 
@@ -205,6 +281,21 @@ where
     key
   }
 
+  fn history_row_prefix(&self, aid: &AID) -> Vec<u8> {
+    let mut key = self.snapshot_row_key(aid);
+    key.push(b'#');
+    key
+  }
+
+  // BR3.1 / FR6.3: 履歴行キーは snapshot 行キー + ゼロ詰め seq_nr 修飾（現行行と同一テーブル・
+  // 同一キー接頭辞で範囲走査可能な形）。key_resolver の既存 API 出力への修飾のみで構成し、
+  // key_resolver 自体は変更しない（U3 境界）
+  fn history_row_key(&self, aid: &AID, seq_nr: usize) -> Vec<u8> {
+    let mut key = self.history_row_prefix(aid);
+    key.extend_from_slice(format!("{:020}", seq_nr).as_bytes());
+    key
+  }
+
   async fn fetch_rows(&self, request: ReadRowsRequest) -> Result<Vec<RowData>, EventStoreReadError> {
     let mut client = self.client.clone();
     let mut stream = client
@@ -216,7 +307,7 @@ where
     let mut acc = RowAccumulator::default();
     while let Some(response) = stream.message().await.map_err(status_to_read_error)? {
       for chunk in response.chunks {
-        Self::process_chunk(&mut acc, chunk, &mut rows)?;
+        Self::process_chunk(&mut acc, chunk, &mut rows);
       }
     }
     if let Some(row) = acc.finish_row() {
@@ -225,30 +316,10 @@ where
     Ok(rows)
   }
 
-  fn process_chunk(
-    acc: &mut RowAccumulator,
-    chunk: CellChunk,
-    rows: &mut Vec<RowData>,
-  ) -> Result<(), EventStoreReadError> {
-    #[cfg(test)]
-    {
-      let family = chunk.family_name.clone().unwrap_or_default();
-      let qualifier = chunk
-        .qualifier
-        .clone()
-        .map(|q| String::from_utf8_lossy(&q).into_owned())
-        .unwrap_or_default();
-      println!(
-        "DEBUG chunk family={}, qualifier={}, value_len={}, commit={:?}",
-        family,
-        qualifier,
-        chunk.value.len(),
-        chunk.row_status
-      );
-    }
+  fn process_chunk(acc: &mut RowAccumulator, chunk: CellChunk, rows: &mut Vec<RowData>) {
     if matches!(chunk.row_status, Some(RowStatus::ResetRow(true))) {
       acc.reset();
-      return Ok(());
+      return;
     }
 
     if !chunk.row_key.is_empty() && acc.key != chunk.row_key {
@@ -278,22 +349,31 @@ where
         rows.push(row);
       }
     }
-
-    Ok(())
   }
 
-  async fn write_event(&self, event: &E) -> Result<(), EventStoreWriteError> {
+  /// journal へ封筒 1 件を 1 行として書き込む。
+  ///
+  /// BR2.1 / FR6.1 / AC2.1.1: 封筒メタデータ 4 点 + payload を 5 セルへ 1:1 で書く。
+  /// manifest セルは v3 新設で、省略時は空文字列がそのまま格納される
+  /// （U1 BR1.2 のラウンドトリップ — AC5.1.1）。payload の分解は封筒の公開アクセサ
+  /// のみで行う（NFR2.3）。
+  async fn write_event(&self, event: &EventEnvelope<AID, P>) -> Result<(), EventStoreWriteError> {
     let row_key = self.event_row_key(event.aggregate_id(), event.seq_nr());
-    let payload = self.event_serializer.serialize(event)?;
+    let payload = self.event_serializer.serialize(event.payload())?;
     let mutations = vec![
-      set_cell(EVENT_FAMILY, b"payload", payload),
-      set_cell(EVENT_FAMILY, b"seq_nr", event.seq_nr().to_string().into_bytes()),
-      set_cell(EVENT_FAMILY, b"aggregate_id", event.aggregate_id().value().into_bytes()),
+      set_cell(EVENT_FAMILY, QUALIFIER_PAYLOAD, payload),
       set_cell(
         EVENT_FAMILY,
-        b"occurred_at",
-        event.occurred_at().timestamp_millis().to_string().into_bytes(),
+        QUALIFIER_AGGREGATE_ID,
+        event.aggregate_id().value().into_bytes(),
       ),
+      set_cell(EVENT_FAMILY, QUALIFIER_SEQ_NR, event.seq_nr().to_string().into_bytes()),
+      set_cell(
+        EVENT_FAMILY,
+        QUALIFIER_OCCURRED_AT,
+        format_occurred_at(event.occurred_at()).into_bytes(),
+      ),
+      set_cell(EVENT_FAMILY, QUALIFIER_MANIFEST, event.manifest().as_bytes().to_vec()),
     ];
     self
       .mutate_row(self.table_path(&self.journal_table_name), row_key, mutations)
@@ -319,7 +399,38 @@ where
     Ok(())
   }
 
-  async fn read_snapshot_row(&self, aid: &AID) -> Result<Option<SnapshotRow<A>>, EventStoreReadError> {
+  /// snapshot 現行行へ CheckAndMutateRow を発行し、述語の成否を返す。
+  ///
+  /// BR1.1 / BR1.2 / NFR4.2: 述語評価とミューテーション適用は Bigtable の単一行原子性
+  /// により原子的で、read→check→write の TOCTOU 窓は構造的に存在しない。
+  /// BR5.1 / NFR5.2: CheckAndMutateRow の単一行原子性は Bigtable API 契約であり、
+  /// エミュレータ（cloud-sdk）と本番でこの意味論は同一である（性能特性の差は検証範囲外）。
+  async fn check_and_mutate_snapshot_row(
+    &self,
+    row_key: Vec<u8>,
+    predicate_filter: RowFilter,
+    true_mutations: Vec<Mutation>,
+    false_mutations: Vec<Mutation>,
+  ) -> Result<bool, EventStoreWriteError> {
+    let mut client = self.client.clone();
+    let response = client
+      .check_and_mutate_row(CheckAndMutateRowRequest {
+        table_name: self.table_path(&self.snapshot_table_name),
+        row_key,
+        predicate_filter: Some(predicate_filter),
+        true_mutations,
+        false_mutations,
+        ..Default::default()
+      })
+      .await
+      .map_err(status_to_write_error)?;
+    Ok(response.into_inner().predicate_matched)
+  }
+
+  /// snapshot 現行行を読み取り、生セル + 解釈済みメタデータを返す。行不在は `None`。
+  ///
+  /// 封筒構築（fetch_latest_snapshot）とプレイメージ複製（履歴行書込）の両方が使う。
+  async fn read_snapshot_row(&self, aid: &AID) -> Result<Option<SnapshotRowImage>, EventStoreReadError> {
     let row_key = self.snapshot_row_key(aid);
     let request = ReadRowsRequest {
       table_name: self.table_path(&self.snapshot_table_name),
@@ -327,9 +438,7 @@ where
         row_keys: vec![row_key],
         row_ranges: vec![],
       }),
-      filter: Some(RowFilter {
-        filter: Some(row_filter::Filter::FamilyNameRegexFilter(SNAPSHOT_FAMILY.to_string())),
-      }),
+      filter: Some(latest_cells_of_family_filter(SNAPSHOT_FAMILY)),
       rows_limit: 1,
       ..Default::default()
     };
@@ -338,59 +447,88 @@ where
       Some(row) => row,
       None => return Ok(None),
     };
-    let payload = row
-      .cells
-      .get(&(SNAPSHOT_FAMILY.to_string(), b"payload".to_vec()))
-      .cloned()
-      .ok_or_else(|| {
-        let available = row
-          .cells
-          .keys()
-          .map(|(family, qualifier)| format!("{}:{}", family, String::from_utf8_lossy(qualifier)))
-          .collect::<Vec<_>>();
-        EventStoreReadError::OtherError(format!(
-          "snapshot payload is missing (available columns: {:?})",
-          available
-        ))
-      })?;
-    let version = row
-      .cells
-      .get(&(SNAPSHOT_FAMILY.to_string(), b"version".to_vec()))
-      .cloned()
-      .ok_or_else(|| EventStoreReadError::OtherError("snapshot version is missing".to_string()))
-      .and_then(|bytes| parse_usize(&bytes))?;
-    let seq_nr = row
-      .cells
-      .get(&(SNAPSHOT_FAMILY.to_string(), b"seq_nr".to_vec()))
-      .cloned()
-      .and_then(|bytes| parse_usize(&bytes).ok())
-      .unwrap_or_default();
-    let mut aggregate = *self.snapshot_serializer.deserialize(&payload)?;
-    aggregate.set_version(version);
-    Ok(Some(SnapshotRow {
-      aggregate,
+    let payload = required_cell(&row, SNAPSHOT_FAMILY, QUALIFIER_PAYLOAD, "snapshot")?.clone();
+    let version = parse_usize(required_cell(&row, SNAPSHOT_FAMILY, QUALIFIER_VERSION, "snapshot")?)?;
+    let seq_nr = parse_usize(required_cell(&row, SNAPSHOT_FAMILY, QUALIFIER_SEQ_NR, "snapshot")?)?;
+    let last_updated_at = required_cell(&row, SNAPSHOT_FAMILY, QUALIFIER_LAST_UPDATED_AT, "snapshot")?.clone();
+    Ok(Some(SnapshotRowImage {
+      payload,
       version,
       seq_nr,
+      last_updated_at,
     }))
+  }
+
+  /// 履歴行を行キー昇順（= seq_nr 昇順 = 旧い順）で読み取る。
+  async fn read_history_rows(&self, aid: &AID) -> Result<Vec<RowData>, EventStoreReadError> {
+    let prefix = self.history_row_prefix(aid);
+    let mut end_key = prefix.clone();
+    end_key.push(0xFF);
+    let request = ReadRowsRequest {
+      table_name: self.table_path(&self.snapshot_table_name),
+      rows: Some(RowSet {
+        row_keys: vec![],
+        row_ranges: vec![RowRange {
+          start_key: Some(StartKey::StartKeyClosed(prefix)),
+          end_key: Some(EndKey::EndKeyOpen(end_key)),
+        }],
+      }),
+      filter: Some(latest_cells_of_family_filter(SNAPSHOT_FAMILY)),
+      ..Default::default()
+    };
+    let mut rows = self.fetch_rows(request).await?;
+    rows.sort_by(|a, b| a.key.cmp(&b.key));
+    Ok(rows)
+  }
+
+  /// journal 行の全セルからイベント封筒を再構成する。
+  ///
+  /// BR2.2 / AC4.1.1: aggregate_id / seq_nr / occurred_at / manifest / payload の全セルを
+  /// 使い、セル欠落は破損データとして読取エラーにする（payload セルのみ読取の廃止 — FR5.1）。
+  /// NFR2.3: 封筒の構築は `EventEnvelope::new` + `with_manifest` の公開ビルダーのみで行う。
+  fn event_envelope_from_row(&self, aid: &AID, row: &RowData) -> Result<EventEnvelope<AID, P>, EventStoreReadError> {
+    let stored_aid = required_cell(row, EVENT_FAMILY, QUALIFIER_AGGREGATE_ID, "journal")?;
+    if stored_aid.as_slice() != aid.value().as_bytes() {
+      return Err(EventStoreReadError::OtherError(format!(
+        "journal aggregate_id cell does not match the requested aggregate: aid={}",
+        aid
+      )));
+    }
+    let seq_nr = parse_usize(required_cell(row, EVENT_FAMILY, QUALIFIER_SEQ_NR, "journal")?)?;
+    let occurred_at = parse_occurred_at(required_cell(row, EVENT_FAMILY, QUALIFIER_OCCURRED_AT, "journal")?)?;
+    let manifest = String::from_utf8(required_cell(row, EVENT_FAMILY, QUALIFIER_MANIFEST, "journal")?.clone())
+      .map_err(|err| EventStoreReadError::OtherError(err.to_string()))?;
+    let payload = self
+      .event_serializer
+      .deserialize(required_cell(row, EVENT_FAMILY, QUALIFIER_PAYLOAD, "journal")?)?;
+    Ok(EventEnvelope::new(aid.clone(), seq_nr, occurred_at, payload).with_manifest(manifest))
   }
 }
 
 #[async_trait]
-impl<AID, A, E> StorageBackend<AID, A, E> for BigtableBackend<AID, A, E>
+impl<AID, A, P> StorageBackend<AID, A, P> for BigtableBackend<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   async fn fetch_latest_snapshot(&self, aid: &AID) -> Result<Option<SnapshotEnvelope<A>>, EventStoreReadError> {
-    Ok(self.read_snapshot_row(aid).await?.map(|row| SnapshotEnvelope {
-      aggregate: row.aggregate,
-      seq_nr: row.seq_nr,
-      version: row.version,
-    }))
+    // FR4.3 / U1 BR2.5: 読取後の set_version 補正は存在しない — version / seq_nr は
+    // 列（セル）側の値をそのまま封筒に載せて返す
+    match self.read_snapshot_row(aid).await? {
+      None => Ok(None),
+      Some(image) => {
+        let aggregate = self.snapshot_serializer.deserialize(&image.payload)?;
+        Ok(Some(SnapshotEnvelope::new(aggregate, image.seq_nr, image.version)))
+      }
+    }
   }
 
-  async fn fetch_events_since(&self, aid: &AID, seq_nr: usize) -> Result<Vec<E>, EventStoreReadError> {
+  async fn fetch_events_since(
+    &self,
+    aid: &AID,
+    seq_nr: usize,
+  ) -> Result<Vec<EventEnvelope<AID, P>>, EventStoreReadError> {
     let prefix = self.event_row_prefix(aid);
     let mut end_key = prefix.clone();
     end_key.push(0xFF);
@@ -405,124 +543,205 @@ where
           end_key: Some(EndKey::EndKeyOpen(end_key)),
         }],
       }),
-      filter: Some(RowFilter {
-        filter: Some(row_filter::Filter::FamilyNameRegexFilter(EVENT_FAMILY.to_string())),
-      }),
+      filter: Some(latest_cells_of_family_filter(EVENT_FAMILY)),
       ..Default::default()
     };
 
     let rows = self.fetch_rows(request).await?;
     let mut events = Vec::with_capacity(rows.len());
     for row in rows {
-      if let Some(payload) = row.cells.get(&(EVENT_FAMILY.to_string(), b"payload".to_vec())) {
-        let event = *self.event_serializer.deserialize(payload)?;
-        events.push(event);
-      }
+      // BR2.2: 各行の全セルから封筒を再構成する（セル欠落は読取エラー）
+      events.push(self.event_envelope_from_row(aid, &row)?);
     }
     Ok(events)
   }
 
   async fn create_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: &A,
     _maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError> {
-    let mut snapshot_payload = aggregate.clone();
-    snapshot_payload.set_version(aggregate.version());
-    let payload = self.snapshot_serializer.serialize(&snapshot_payload)?;
+    // BR2.3 / AC2.3.3: snapshot payload は純ドメイン内容のみ（version 注入の廃止 — FR4.2）
+    let payload = self.snapshot_serializer.serialize(aggregate)?;
 
-    let mutations = vec![
-      set_cell(SNAPSHOT_FAMILY, b"payload", payload),
+    // BR1.2 / FR6.2 / P4: 新規作成は CheckAndMutateRow の述語不成立側（version セル不在）で
+    // 原子的に初期化する。false ミューテーションで version=1 / seq_nr=event.seq_nr() /
+    // last_updated_at=event.occurred_at() / payload を設定する
+    let false_mutations = vec![
+      set_cell(SNAPSHOT_FAMILY, QUALIFIER_PAYLOAD, payload),
+      set_cell(SNAPSHOT_FAMILY, QUALIFIER_VERSION, 1_usize.to_string().into_bytes()),
       set_cell(
         SNAPSHOT_FAMILY,
-        b"version",
-        aggregate.version().to_string().into_bytes(),
+        QUALIFIER_SEQ_NR,
+        event.seq_nr().to_string().into_bytes(),
       ),
-      set_cell(SNAPSHOT_FAMILY, b"seq_nr", aggregate.seq_nr().to_string().into_bytes()),
       set_cell(
         SNAPSHOT_FAMILY,
-        b"last_updated_at",
+        QUALIFIER_LAST_UPDATED_AT,
         event.occurred_at().timestamp_millis().to_string().into_bytes(),
       ),
     ];
-
-    self
-      .mutate_row(
-        self.table_path(&self.snapshot_table_name),
+    let predicate_matched = self
+      .check_and_mutate_snapshot_row(
         self.snapshot_row_key(event.aggregate_id()),
-        mutations,
+        version_exists_predicate(),
+        vec![],
+        false_mutations,
       )
       .await?;
+    if predicate_matched {
+      // 既存集約への create は楽観ロックエラー（統一書式・actual なし。
+      // 新規作成の expected_version は 0 — U1 の W1 規約）
+      return Err(EventStoreWriteError::OptimisticLockError(
+        format_optimistic_lock_message(&event.aggregate_id().to_string(), 0, None),
+      ));
+    }
 
+    // BR2.1: journal へ封筒 5 セルを書込（CAS 成功後の別行書込 — 現行と同じ順序・非トランザクション性）
     self.write_event(event).await
   }
 
   async fn update_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: Option<&A>,
     expected_version: usize,
-    _maintenance: &SnapshotMaintenance,
+    maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError> {
-    let snapshot = self
-      .read_snapshot_row(event.aggregate_id())
-      .await
-      .map_err(|err| EventStoreWriteError::OtherError(err.to_string()))?
-      .ok_or_else(|| {
-        EventStoreWriteError::OtherError(format!("snapshot not found for aggregate {}", event.aggregate_id()))
-      })?;
-    if snapshot.version != expected_version {
-      return Err(EventStoreWriteError::OptimisticLockError(
-        format_optimistic_lock_message(
-          &event.aggregate_id().to_string(),
-          expected_version,
-          Some(snapshot.version),
-        ),
-      ));
-    }
+    let aid = event.aggregate_id();
 
-    let mut updates = vec![
+    // BR3.1 / P5: プレイメージ読取は keep_snapshot_count = Some(n) かつスナップショット付き
+    // 更新の場合のみ行う。読取 version ≠ expected_version なら履歴コピーはしない（version は
+    // 単調増加のため後続 CAS は必ず失敗する — 競合判定はあくまで述語側）。読取失敗は
+    // ベストエフォートとして warn 記録のみで継続する（競合・接続不能の実エラーは直後の CAS が返す）
+    let pre_image = if maintenance.keep_snapshot_count.is_some() && aggregate.is_some() {
+      match self.read_snapshot_row(aid).await {
+        Ok(Some(image)) if image.version == expected_version => Some(image),
+        Ok(_) => None,
+        Err(err) => {
+          tracing::warn!(
+            "snapshot pre-image read failed: aid={}, kind={}",
+            aid,
+            read_error_kind(&err)
+          );
+          None
+        }
+      }
+    } else {
+      None
+    };
+
+    let mut true_mutations = vec![
       set_cell(
         SNAPSHOT_FAMILY,
-        b"version",
+        QUALIFIER_VERSION,
         (expected_version + 1).to_string().into_bytes(),
       ),
       set_cell(
         SNAPSHOT_FAMILY,
-        b"last_updated_at",
+        QUALIFIER_LAST_UPDATED_AT,
         event.occurred_at().timestamp_millis().to_string().into_bytes(),
       ),
     ];
-
     if let Some(aggregate) = aggregate {
-      let mut snapshot_payload = aggregate.clone();
-      snapshot_payload.set_version(expected_version + 1);
-      let payload = self.snapshot_serializer.serialize(&snapshot_payload)?;
-      updates.push(set_cell(SNAPSHOT_FAMILY, b"payload", payload));
-      updates.push(set_cell(
+      // BR2.3 / AC2.3.3: payload は純ドメイン内容のみ（version 注入の廃止 — FR4.2）。
+      // seq_nr セルは event.seq_nr() を採用する（U1 SPI 契約）
+      let payload = self.snapshot_serializer.serialize(aggregate)?;
+      true_mutations.push(set_cell(SNAPSHOT_FAMILY, QUALIFIER_PAYLOAD, payload));
+      true_mutations.push(set_cell(
         SNAPSHOT_FAMILY,
-        b"seq_nr",
-        aggregate.seq_nr().to_string().into_bytes(),
+        QUALIFIER_SEQ_NR,
+        event.seq_nr().to_string().into_bytes(),
       ));
     }
 
-    self
-      .mutate_row(
-        self.table_path(&self.snapshot_table_name),
-        self.snapshot_row_key(event.aggregate_id()),
-        updates,
+    // BR1.1 / FR6.2 / NFR4.2 / AC2.2.1: read→check→write の非トランザクション実装を
+    // CheckAndMutateRow による単一行原子性 CAS で置換する
+    let predicate_matched = self
+      .check_and_mutate_snapshot_row(
+        self.snapshot_row_key(aid),
+        version_matches_predicate(expected_version),
+        true_mutations,
+        vec![],
       )
       .await?;
+    if !predicate_matched {
+      // 追補読取で actual_version を取得できる場合のみ付与する（統一書式の許可キー内）。
+      // 行不在（不在集約への更新）は actual なし — U1 リファレンス意味論との対称性
+      let actual_version = match self.read_snapshot_row(aid).await {
+        Ok(Some(image)) => Some(image.version),
+        _ => None,
+      };
+      return Err(EventStoreWriteError::OptimisticLockError(
+        format_optimistic_lock_message(&aid.to_string(), expected_version, actual_version),
+      ));
+    }
 
+    // BR3.1 / P5 / NFR3.5: CAS 勝者のみがプレイメージを別呼び出しの mutate_row で履歴行へ書く
+    // （CheckAndMutateRow は単一行にしか作用しないため同一 CAS には束ねられない。敗者は上で
+    // 復帰済みなので二重書込は発生しない）。失敗はエラーを返さず warn で記録して続行する
+    // （履歴は剪定対象の付随データであり、CAS 成功後のエラー返却は呼出し側の再試行を偽競合に
+    // する。warn には aid + エラー種別のみを載せ、payload は載せない）
+    if let Some(image) = pre_image {
+      let history_key = self.history_row_key(aid, image.seq_nr);
+      let mutations = vec![
+        set_cell(SNAPSHOT_FAMILY, QUALIFIER_PAYLOAD, image.payload),
+        set_cell(
+          SNAPSHOT_FAMILY,
+          QUALIFIER_VERSION,
+          image.version.to_string().into_bytes(),
+        ),
+        set_cell(SNAPSHOT_FAMILY, QUALIFIER_SEQ_NR, image.seq_nr.to_string().into_bytes()),
+        set_cell(SNAPSHOT_FAMILY, QUALIFIER_LAST_UPDATED_AT, image.last_updated_at),
+      ];
+      if let Err(err) = self
+        .mutate_row(self.table_path(&self.snapshot_table_name), history_key, mutations)
+        .await
+      {
+        tracing::warn!(
+          "snapshot history write failed: aid={}, kind={}",
+          aid,
+          write_error_kind(&err)
+        );
+      }
+    }
+
+    // BR2.1: journal へ封筒 5 セルを書込
     self.write_event(event).await
   }
 
-  async fn on_event_persisted(
-    &self,
-    _aid: &AID,
-    _maintenance: &SnapshotMaintenance,
-  ) -> Result<(), EventStoreWriteError> {
+  async fn on_event_persisted(&self, aid: &AID, maintenance: &SnapshotMaintenance) -> Result<(), EventStoreWriteError> {
+    // BR3.1 / FR6.3 / AC2.3.4: 保持ポリシーの実行点。keep_snapshot_count = None は
+    // 現行互換の no-op（履歴行も書かれないため剪定対象が存在しない）
+    let keep = match maintenance.keep_snapshot_count {
+      Some(keep) => keep,
+      None => return Ok(()),
+    };
+    let rows = self.read_history_rows(aid).await.map_err(read_error_to_write_error)?;
+    // 行キーは snapshot 行キー + ゼロ詰め seq_nr 修飾のため、キー昇順 = 旧い順。
+    // 新しい順に keep 件残し、先頭（旧い側）の超過分を DeleteFromRow で剪定する
+    let excess = rows.len().saturating_sub(keep);
+    // delete_ttl 併用時は、保持数内でも期限超過の履歴行を削除する（BR3.1）
+    let cutoff_millis = maintenance.delete_ttl.map(|ttl| (Utc::now() - ttl).timestamp_millis());
+    for (index, row) in rows.into_iter().enumerate() {
+      let expired = cutoff_millis.is_some_and(|cutoff| {
+        row
+          .cells
+          .get(&(SNAPSHOT_FAMILY.to_string(), QUALIFIER_LAST_UPDATED_AT.to_vec()))
+          .and_then(|bytes| parse_millis(bytes))
+          .is_some_and(|millis| millis < cutoff)
+      });
+      if index < excess || expired {
+        self
+          .mutate_row(
+            self.table_path(&self.snapshot_table_name),
+            row.key,
+            vec![delete_from_row()],
+          )
+          .await?;
+      }
+    }
     Ok(())
   }
 }
@@ -540,12 +759,6 @@ impl RowAccumulator {
   fn start_cell(&mut self) {
     if let (Some(family), Some(qualifier)) = (&self.current_family, &self.current_qualifier) {
       let value = std::mem::take(&mut self.current_value);
-      println!(
-        "DEBUG insert cell {}:{} len={}",
-        family,
-        String::from_utf8_lossy(qualifier),
-        value.len()
-      );
       self.cells.entry((family.clone(), qualifier.clone())).or_insert(value);
     } else {
       self.current_value.clear();
@@ -559,13 +772,12 @@ impl RowAccumulator {
       return None;
     }
     self.start_cell();
+    let key = std::mem::take(&mut self.key);
     if self.cells.is_empty() {
-      self.key.clear();
       return None;
     }
-    self.key.clear();
     let cells = std::mem::take(&mut self.cells);
-    Some(RowData { cells })
+    Some(RowData { key, cells })
   }
 
   fn reset(&mut self) {
@@ -578,13 +790,19 @@ impl RowAccumulator {
 }
 
 struct RowData {
+  key: Vec<u8>,
   cells: HashMap<(String, Vec<u8>), Vec<u8>>,
 }
 
-struct SnapshotRow<A> {
-  aggregate: A,
+/// snapshot 現行行の読取結果（生セル + 解釈済みメタデータ）。
+///
+/// payload / last_updated_at は生バイト列のまま保持し、プレイメージの履歴行複製で
+/// payload を解釈せずに転記できるようにする（NFR2.3 — payload の中身を覗く分岐を持ち込まない）。
+struct SnapshotRowImage {
+  payload: Vec<u8>,
   version: usize,
   seq_nr: usize,
+  last_updated_at: Vec<u8>,
 }
 
 fn set_cell(family: &str, qualifier: &[u8], value: Vec<u8>) -> Mutation {
@@ -598,16 +816,150 @@ fn set_cell(family: &str, qualifier: &[u8], value: Vec<u8>) -> Mutation {
   }
 }
 
+fn delete_from_row() -> Mutation {
+  Mutation {
+    mutation: Some(mutation::Mutation::DeleteFromRow(mutation::DeleteFromRow {})),
+  }
+}
+
+fn chain_filter(filters: Vec<row_filter::Filter>) -> RowFilter {
+  RowFilter {
+    filter: Some(row_filter::Filter::Chain(row_filter::Chain {
+      filters: filters
+        .into_iter()
+        .map(|filter| RowFilter { filter: Some(filter) })
+        .collect(),
+    })),
+  }
+}
+
+// 読取は対象ファミリの各列の最新セルのみを対象にする（set_cell が残す旧セルバージョンの
+// 誤読防止 — BR1.1 の最新セル限定と同根）
+fn latest_cells_of_family_filter(family: &str) -> RowFilter {
+  chain_filter(vec![
+    row_filter::Filter::FamilyNameRegexFilter(family.to_string()),
+    row_filter::Filter::CellsPerColumnLimitFilter(1),
+  ])
+}
+
+// BR1.2 / P4: 新規作成パスの述語 — version セルの存在チェック（2 フィルタ）。
+// 新規作成には比較対象の expected_version が存在しないため値一致フィルタを持たない
+// （列スコープは更新パスと同じ理由で必須）
+fn version_exists_predicate() -> RowFilter {
+  chain_filter(vec![
+    row_filter::Filter::FamilyNameRegexFilter(SNAPSHOT_FAMILY.to_string()),
+    row_filter::Filter::ColumnQualifierRegexFilter(QUALIFIER_VERSION.to_vec()),
+  ])
+}
+
+// BR1.1 / P4 / NFR4.2: 更新パスの述語 — 列スコープ + 最新セル限定 + expected_version 完全一致の
+// 4 フィルタチェーン。列スコープなしの ValueRangeFilter は行内全セル（seq_nr 含む）に一致する
+// ため禁止。最新セル限定（CellsPerColumnLimitFilter(1)）は set_cell が残す旧セルバージョンとの
+// 誤一致を防ぐため必須
+fn version_matches_predicate(expected_version: usize) -> RowFilter {
+  let expected = expected_version.to_string().into_bytes();
+  chain_filter(vec![
+    row_filter::Filter::FamilyNameRegexFilter(SNAPSHOT_FAMILY.to_string()),
+    row_filter::Filter::ColumnQualifierRegexFilter(QUALIFIER_VERSION.to_vec()),
+    row_filter::Filter::CellsPerColumnLimitFilter(1),
+    row_filter::Filter::ValueRangeFilter(ValueRange {
+      start_value: Some(StartValue::StartValueClosed(expected.clone())),
+      end_value: Some(EndValue::EndValueClosed(expected)),
+    }),
+  ])
+}
+
+/// gRPC ステータスの中立表現。
+///
+/// BR4.1 / NFR3.4 / P6: gRPC の失敗はこの写像点 1 箇所で IOError 系へ包み、保持するのは
+/// ステータスコードのみとする。生ステータスのメッセージ（テーブルパス・プロジェクト ID・
+/// 接続先が混入しうる）は展開しない。
+#[derive(Debug)]
+struct BigtableStatusError {
+  code: tonic::Code,
+}
+
+impl std::fmt::Display for BigtableStatusError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "grpc status: {:?}", self.code)
+  }
+}
+
+impl std::error::Error for BigtableStatusError {}
+
 fn status_to_read_error(status: Status) -> EventStoreReadError {
-  EventStoreReadError::IOError(Box::new(status))
+  EventStoreReadError::IOError(Box::new(BigtableStatusError { code: status.code() }))
 }
 
 fn status_to_write_error(status: Status) -> EventStoreWriteError {
-  EventStoreWriteError::IOError(Box::new(status))
+  EventStoreWriteError::IOError(Box::new(BigtableStatusError { code: status.code() }))
+}
+
+// on_event_persisted（書込フック）内の読取失敗を、種別を保存したまま書込エラーへ写像する（BR4.1）
+fn read_error_to_write_error(err: EventStoreReadError) -> EventStoreWriteError {
+  match err {
+    EventStoreReadError::IOError(source) => EventStoreWriteError::IOError(source),
+    EventStoreReadError::DeserializationError(source) => EventStoreWriteError::OtherError(source.to_string()),
+    EventStoreReadError::OtherError(message) => EventStoreWriteError::OtherError(message),
+  }
+}
+
+// NFR3.5 / P5: warn ログに載せるのはエラー種別のみ（payload・接続情報・生ステータスを展開しない）
+fn read_error_kind(err: &EventStoreReadError) -> &'static str {
+  match err {
+    EventStoreReadError::DeserializationError(_) => "DeserializationError",
+    EventStoreReadError::IOError(_) => "IOError",
+    EventStoreReadError::OtherError(_) => "OtherError",
+  }
+}
+
+fn write_error_kind(err: &EventStoreWriteError) -> &'static str {
+  match err {
+    EventStoreWriteError::SerializationError(_) => "SerializationError",
+    EventStoreWriteError::OptimisticLockError(_) => "OptimisticLockError",
+    EventStoreWriteError::ContractViolation(_) => "ContractViolation",
+    EventStoreWriteError::IOError(_) => "IOError",
+    EventStoreWriteError::OtherError(_) => "OtherError",
+  }
+}
+
+// FR1.4 / U1 BR1.3: occurred_at はドメイン供給値のまま保存・読出しする。epoch millis 格納では
+// サブミリ秒精度が失われ供給値の完全往復（共有シナリオの occurred_at 同値 assert — C3）を
+// 満たせないため、ナノ秒精度の RFC 3339 文字列でセルへ格納する
+fn format_occurred_at(occurred_at: &DateTime<Utc>) -> String {
+  occurred_at.to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+fn parse_occurred_at(bytes: &[u8]) -> Result<DateTime<Utc>, EventStoreReadError> {
+  let text = std::str::from_utf8(bytes).map_err(|err| EventStoreReadError::OtherError(err.to_string()))?;
+  DateTime::parse_from_rfc3339(text)
+    .map(|occurred_at| occurred_at.with_timezone(&Utc))
+    .map_err(|err| EventStoreReadError::OtherError(err.to_string()))
+}
+
+// BR2.2: セル欠落は破損データとして読取エラーにする（メッセージは行種別とファミリ・列名のみ）
+fn required_cell<'a>(
+  row: &'a RowData,
+  family: &str,
+  qualifier: &[u8],
+  row_kind: &str,
+) -> Result<&'a Vec<u8>, EventStoreReadError> {
+  row.cells.get(&(family.to_string(), qualifier.to_vec())).ok_or_else(|| {
+    EventStoreReadError::OtherError(format!(
+      "{} row cell is missing: {}:{}",
+      row_kind,
+      family,
+      String::from_utf8_lossy(qualifier)
+    ))
+  })
 }
 
 fn parse_usize(bytes: &[u8]) -> Result<usize, EventStoreReadError> {
   let s = std::str::from_utf8(bytes).map_err(|err| EventStoreReadError::OtherError(err.to_string()))?;
   s.parse::<usize>()
     .map_err(|err| EventStoreReadError::OtherError(err.to_string()))
+}
+
+fn parse_millis(bytes: &[u8]) -> Option<i64> {
+  std::str::from_utf8(bytes).ok()?.parse::<i64>().ok()
 }

--- a/lib/src/event_store_for_bigtable.rs
+++ b/lib/src/event_store_for_bigtable.rs
@@ -112,6 +112,10 @@ where
   ///
   /// BR4.1 / P3: 検証（`Some(0)` の拒否）は `GenericEventStore` 側の 1 箇所で行い、
   /// このラッパーは Result を素通しする。
+  ///
+  /// BR3.1: 設定を有効にすると各書込後に履歴剪定フックが走る。剪定フック自体の読取・削除の
+  /// 失敗は書込エラーとして呼出し側へ伝播する（このとき journal / snapshot 現行行の書込は
+  /// 既に成功している）。
   pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Result<Self, EventStoreWriteError> {
     self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count)?;
     Ok(self)
@@ -614,7 +618,10 @@ where
     // BR3.1 / P5: プレイメージ読取は keep_snapshot_count = Some(n) かつスナップショット付き
     // 更新の場合のみ行う。読取 version ≠ expected_version なら履歴コピーはしない（version は
     // 単調増加のため後続 CAS は必ず失敗する — 競合判定はあくまで述語側）。読取失敗は
-    // ベストエフォートとして warn 記録のみで継続する（競合・接続不能の実エラーは直後の CAS が返す）
+    // ベストエフォートとして warn 記録のみで継続する。接続系の実エラー（IOError）は直後の
+    // CAS が同根で返す一方、行データ破損（セル欠落・整数パース失敗等の OtherError）は CAS の
+    // 検査対象が version セルのみのため CAS 自体は成功しうる — その場合は当該更新の履歴コピー
+    // だけが静かにスキップされ、破損自体は読取経路（fetch_latest_snapshot 等）で顕在化する
     let pre_image = if maintenance.keep_snapshot_count.is_some() && aggregate.is_some() {
       match self.read_snapshot_row(aid).await {
         Ok(Some(image)) if image.version == expected_version => Some(image),
@@ -713,7 +720,11 @@ where
 
   async fn on_event_persisted(&self, aid: &AID, maintenance: &SnapshotMaintenance) -> Result<(), EventStoreWriteError> {
     // BR3.1 / FR6.3 / AC2.3.4: 保持ポリシーの実行点。keep_snapshot_count = None は
-    // 現行互換の no-op（履歴行も書かれないため剪定対象が存在しない）
+    // 現行互換の no-op（履歴行も書かれないため剪定対象が存在しない）。
+    // 剪定フック自体の読取・削除の失敗は warn 継続にせず呼出し側へ伝播する（CAS 成功直後の
+    // 履歴コピーの warn 継続とは扱いが異なる意図的な非対称 — 剪定は明示設定に基づく保持契約の
+    // 実行であり、失敗の黙殺は「エラーを握り潰さない」原則に反するため）。journal / snapshot
+    // 現行行の書込は伝播時点で既に成功している点に注意
     let keep = match maintenance.keep_snapshot_count {
       Some(keep) => keep,
       None => return Ok(()),

--- a/lib/src/event_store_for_bigtable_test.rs
+++ b/lib/src/event_store_for_bigtable_test.rs
@@ -1,13 +1,182 @@
+use std::collections::BTreeSet;
+
+use chrono::Utc;
 use event_store_adapter_test_utils_rs::bigtable::create_table;
 use event_store_adapter_test_utils_rs::docker::bigtable_emulator;
 use event_store_adapter_test_utils_rs::id_generator::id_generate;
 use googleapis_tonic_google_bigtable_admin_v2::google::bigtable::admin::v2::bigtable_table_admin_client::BigtableTableAdminClient;
 use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::bigtable_client::BigtableClient;
+use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::{
+  row_filter,
+  row_range::{EndKey, StartKey},
+  ReadRowsRequest, RowFilter, RowRange, RowSet,
+};
 use tonic::transport::Channel;
 
+use crate::event_envelope::EventEnvelope;
 use crate::event_store_for_bigtable::EventStoreForBigtable;
-use crate::event_store_test_support::{exercise_user_account_flow, init_tracing, UserAccountId};
+use crate::event_store_test_support::{
+  assert_optimistic_lock_message_format, exercise_user_account_flow, find_by_id, init_tracing, UserAccount,
+  UserAccountEvent, UserAccountId, CREATED_MANIFEST, RENAMED_MANIFEST,
+};
+use crate::key_resolver::{DefaultKeyResolver, KeyResolver};
+use crate::types::{AggregateId, EventStore, EventStoreReadError, EventStoreWriteError};
 
+const PROJECT: &str = "test-project";
+const INSTANCE: &str = "test-instance";
+const JOURNAL_TABLE: &str = "journal";
+const SNAPSHOT_TABLE: &str = "snapshot";
+const SNAPSHOT_FAMILY: &str = "snapshot";
+const SHARD_COUNT: u64 = 64;
+
+type UserAccountStore = EventStoreForBigtable<UserAccountId, UserAccount, UserAccountEvent>;
+
+/// エミュレータへ接続し、テーブルを作成してストアを構築する（1 テストにつき独立したエミュレータ）。
+async fn connect_store(port: u16) -> (BigtableClient<Channel>, UserAccountStore) {
+  let endpoint = format!("http://127.0.0.1:{}", port);
+  let channel = Channel::from_shared(endpoint)
+    .expect("invalid endpoint")
+    .connect()
+    .await
+    .expect("failed to connect to emulator");
+
+  let parent = format!("projects/{}/instances/{}", PROJECT, INSTANCE);
+  let mut table_admin = BigtableTableAdminClient::new(channel.clone());
+  create_table(&mut table_admin, &parent, JOURNAL_TABLE, &["event"]).await;
+  create_table(&mut table_admin, &parent, SNAPSHOT_TABLE, &["snapshot"]).await;
+
+  let client = BigtableClient::new(channel);
+  let store = UserAccountStore::new(
+    client.clone(),
+    PROJECT.to_string(),
+    INSTANCE.to_string(),
+    JOURNAL_TABLE.to_string(),
+    SNAPSHOT_TABLE.to_string(),
+    SHARD_COUNT,
+  );
+  (client, store)
+}
+
+fn snapshot_table_path() -> String {
+  format!("projects/{}/instances/{}/tables/{}", PROJECT, INSTANCE, SNAPSHOT_TABLE)
+}
+
+// バックエンドの行キースキーム（key_resolver の partition key + type_name + value）の複製。
+// 履歴行の物理配置（snapshot 行キー + ゼロ詰め seq_nr 修飾）を白箱検証するために使う
+fn snapshot_row_key(id: &UserAccountId) -> Vec<u8> {
+  let resolver = DefaultKeyResolver::<UserAccountId>::default();
+  format!(
+    "{}#{}#{}",
+    resolver.resolve_partition_key(id, SHARD_COUNT),
+    id.type_name(),
+    id.value()
+  )
+  .into_bytes()
+}
+
+fn history_row_prefix(id: &UserAccountId) -> Vec<u8> {
+  let mut key = snapshot_row_key(id);
+  key.push(b'#');
+  key
+}
+
+fn history_row_key(id: &UserAccountId, seq_nr: usize) -> Vec<u8> {
+  let mut key = history_row_prefix(id);
+  key.extend_from_slice(format!("{:020}", seq_nr).as_bytes());
+  key
+}
+
+// ファミリ + 対象列 + 最新セル限定 → 1 行 = 1 セルになり、チャンク走査を単純化できる
+fn single_cell_filter(qualifier: &[u8]) -> RowFilter {
+  let filters = vec![
+    row_filter::Filter::FamilyNameRegexFilter(SNAPSHOT_FAMILY.to_string()),
+    row_filter::Filter::ColumnQualifierRegexFilter(qualifier.to_vec()),
+    row_filter::Filter::CellsPerColumnLimitFilter(1),
+  ];
+  RowFilter {
+    filter: Some(row_filter::Filter::Chain(row_filter::Chain {
+      filters: filters
+        .into_iter()
+        .map(|filter| RowFilter { filter: Some(filter) })
+        .collect(),
+    })),
+  }
+}
+
+/// snapshot テーブルの履歴行キーを昇順で返す（剪定結果の白箱検証用）。
+async fn scan_history_row_keys(client: &BigtableClient<Channel>, id: &UserAccountId) -> Vec<Vec<u8>> {
+  let prefix = history_row_prefix(id);
+  let mut end_key = prefix.clone();
+  end_key.push(0xFF);
+  let request = ReadRowsRequest {
+    table_name: snapshot_table_path(),
+    rows: Some(RowSet {
+      row_keys: vec![],
+      row_ranges: vec![RowRange {
+        start_key: Some(StartKey::StartKeyClosed(prefix)),
+        end_key: Some(EndKey::EndKeyOpen(end_key)),
+      }],
+    }),
+    filter: Some(single_cell_filter(b"version")),
+    ..Default::default()
+  };
+  let mut stream = client
+    .clone()
+    .read_rows(request)
+    .await
+    .expect("read_rows failed")
+    .into_inner();
+  let mut keys = BTreeSet::new();
+  while let Some(response) = stream.message().await.expect("read_rows stream failed") {
+    for chunk in response.chunks {
+      if !chunk.row_key.is_empty() {
+        keys.insert(chunk.row_key);
+      }
+    }
+  }
+  keys.into_iter().collect()
+}
+
+/// snapshot テーブルの 1 行 1 セルを読み取る（payload 純度の白箱検証用）。
+async fn read_snapshot_cell(client: &BigtableClient<Channel>, row_key: Vec<u8>, qualifier: &[u8]) -> Option<Vec<u8>> {
+  let request = ReadRowsRequest {
+    table_name: snapshot_table_path(),
+    rows: Some(RowSet {
+      row_keys: vec![row_key],
+      row_ranges: vec![],
+    }),
+    filter: Some(single_cell_filter(qualifier)),
+    rows_limit: 1,
+    ..Default::default()
+  };
+  let mut stream = client
+    .clone()
+    .read_rows(request)
+    .await
+    .expect("read_rows failed")
+    .into_inner();
+  let mut value = Vec::new();
+  let mut found = false;
+  while let Some(response) = stream.message().await.expect("read_rows stream failed") {
+    for chunk in response.chunks {
+      if chunk.family_name.is_some() || chunk.qualifier.is_some() {
+        found = true;
+      }
+      value.extend_from_slice(&chunk.value);
+    }
+  }
+  found.then_some(value)
+}
+
+fn renamed_envelope(
+  id: &UserAccountId,
+  seq_nr: usize,
+  payload: UserAccountEvent,
+) -> EventEnvelope<UserAccountId, UserAccountEvent> {
+  EventEnvelope::new(id.clone(), seq_nr, Utc::now(), payload).with_manifest(RENAMED_MANIFEST)
+}
+
+// FR7.1 / C3 / AC5.1.1: 共有シナリオ（8 手順・封筒メタデータ往復 assert 含む）を無改変で green にする
 #[tokio::test]
 async fn test_event_store_on_bigtable() {
   init_tracing();
@@ -17,37 +186,284 @@ async fn test_event_store_on_bigtable() {
     .get_host_port_ipv4(8086)
     .await
     .expect("Failed to get Bigtable port");
+  let (_client, mut event_store) = connect_store(port).await;
 
-  let endpoint = format!("http://127.0.0.1:{}", port);
-  let channel = Channel::from_shared(endpoint.clone())
-    .expect("invalid endpoint")
-    .connect()
-    .await
-    .expect("failed to connect to emulator");
-
-  let project = "test-project";
-  let instance = "test-instance";
-  let parent = format!("projects/{}/instances/{}", project, instance);
-
-  let mut table_admin = BigtableTableAdminClient::new(channel.clone());
-  create_table(&mut table_admin, &parent, "journal", &["event"]).await;
-  create_table(&mut table_admin, &parent, "snapshot", &["snapshot"]).await;
-
-  let client = BigtableClient::new(channel.clone());
-
-  let mut event_store = EventStoreForBigtable::new(
-    client,
-    project.to_string(),
-    instance.to_string(),
-    "journal".to_string(),
-    "snapshot".to_string(),
-    64,
-  );
-
-  let id_value = id_generate();
-  let id = UserAccountId::new(id_value.to_string());
+  let id = UserAccountId::new(id_generate().to_string());
 
   exercise_user_account_flow(&mut event_store, &id)
     .await
     .expect("scenario failed");
+}
+
+// NFR4.1 / AC2.2.1 / BR1.1: 同時更新の競合パス — 同一 expected_version の並行更新 2 本のうち
+// 一方のみが成功し、他方は統一書式（許可キーのみ）の OptimisticLockError になる。
+// BR5.1 / NFR5.2: CheckAndMutateRow の述語評価とミューテーション適用の単一行原子性は
+// Bigtable API 契約であり、エミュレータ（cloud-sdk）と本番で意味論は同一である。
+// 本テストの検証結果はそのまま本番の競合意味論に対応する（性能特性の差は検証範囲外）
+#[tokio::test]
+async fn test_event_store_on_bigtable_concurrent_conflict_yields_optimistic_lock_error() {
+  init_tracing();
+
+  let node = bigtable_emulator().await;
+  let port = node
+    .get_host_port_ipv4(8086)
+    .await
+    .expect("Failed to get Bigtable port");
+  let (_client, store) = connect_store(port).await;
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  {
+    let mut writer = store.clone();
+    writer
+      .persist_event_and_snapshot(
+        EventEnvelope::new(id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST),
+        user_account,
+        0,
+      )
+      .await
+      .expect("creation failed");
+  }
+
+  let mut store_a = store.clone();
+  let mut store_b = store.clone();
+  let mut account_a = find_by_id(&store_a, &id).await.unwrap().unwrap();
+  let mut account_b = find_by_id(&store_b, &id).await.unwrap().unwrap();
+  let envelope_a = renamed_envelope(&id, account_a.seq_nr + 1, account_a.state.rename("conflict-a").unwrap());
+  let envelope_b = renamed_envelope(&id, account_b.seq_nr + 1, account_b.state.rename("conflict-b").unwrap());
+  let version_a = account_a.version;
+  let version_b = account_b.version;
+
+  let (result_a, result_b) = tokio::join!(
+    async move { store_a.persist_event(envelope_a, version_a).await },
+    async move { store_b.persist_event(envelope_b, version_b).await },
+  );
+
+  let err = match (result_a, result_b) {
+    (Err(err), Ok(())) | (Ok(()), Err(err)) => err,
+    (Ok(()), Ok(())) => panic!("exactly one concurrent write must win, but both succeeded"),
+    (Err(err_a), Err(err_b)) => panic!(
+      "exactly one concurrent write must win, but both failed: {:?} / {:?}",
+      err_a, err_b
+    ),
+  };
+  match err {
+    EventStoreWriteError::OptimisticLockError(message) => {
+      assert!(
+        message.starts_with(&format!("optimistic lock failed, aid={}, expected_version=1", id)),
+        "unexpected message: {}",
+        message
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
+}
+
+// AC2.2.2 / AC4.1.3 / BR4.1 / NFR3.4: 接続不能でも panic せず IOError 系の中立エラーが返り、
+// メッセージに接続文字列・テーブルパス・生ステータス詳細が展開されない（P6）。
+// 未使用ポートへの接続で実現する（現行のエラー契約テストパターン踏襲 — Docker 不要）
+#[tokio::test]
+async fn test_event_store_on_bigtable_unreachable_endpoint_returns_io_error() {
+  init_tracing();
+
+  let channel = Channel::from_shared("http://127.0.0.1:1".to_string())
+    .expect("invalid endpoint")
+    .connect_lazy();
+  let client = BigtableClient::new(channel);
+  let mut store: UserAccountStore = EventStoreForBigtable::new(
+    client,
+    PROJECT.to_string(),
+    INSTANCE.to_string(),
+    JOURNAL_TABLE.to_string(),
+    SNAPSHOT_TABLE.to_string(),
+    SHARD_COUNT,
+  );
+
+  let id = UserAccountId::new(id_generate().to_string());
+
+  // 読取経路
+  let read_result = store.get_latest_snapshot_by_id(&id).await;
+  match read_result {
+    Err(EventStoreReadError::IOError(source)) => {
+      let message = source.to_string();
+      assert!(!message.contains("://"), "message must not contain connection strings");
+      assert!(!message.contains("projects/"), "message must not contain table paths");
+    }
+    other => panic!("expected IOError, got {:?}", other),
+  }
+
+  // 書込経路（W1: create の CAS 呼び出しが接続不能）
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  let write_result = store
+    .persist_event_and_snapshot(EventEnvelope::new(id.clone(), 1, Utc::now(), created), user_account, 0)
+    .await;
+  match write_result {
+    Err(EventStoreWriteError::IOError(source)) => {
+      let message = source.to_string();
+      assert!(!message.contains("://"), "message must not contain connection strings");
+      assert!(!message.contains("projects/"), "message must not contain table paths");
+    }
+    other => panic!("expected IOError, got {:?}", other),
+  }
+}
+
+// U1 リファレンス意味論との対称性: 未作成（Absent）の集約への更新系呼び出しは
+// actual_version なし書式の OptimisticLockError を返す（CAS 述語不成立 + 追補読取で行不在）
+#[tokio::test]
+async fn test_event_store_on_bigtable_update_on_absent_aggregate_yields_optimistic_lock_error() {
+  init_tracing();
+
+  let node = bigtable_emulator().await;
+  let port = node
+    .get_host_port_ipv4(8086)
+    .await
+    .expect("Failed to get Bigtable port");
+  let (_client, mut store) = connect_store(port).await;
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, _created) = UserAccount::new(id.clone(), "test".to_string());
+
+  // 未作成のまま seq_nr=2 / expected_version=1 のスナップショット付き更新（W3 経路）を呼ぶ
+  let envelope = EventEnvelope::new(
+    id.clone(),
+    2,
+    Utc::now(),
+    UserAccountEvent::Renamed {
+      name: "ghost".to_string(),
+    },
+  );
+  let result = store.persist_event_and_snapshot(envelope, user_account, 1).await;
+  match result {
+    Err(EventStoreWriteError::OptimisticLockError(message)) => {
+      // actual_version を含まない書式であることを完全一致で固定する
+      assert_eq!(
+        message,
+        format!("optimistic lock failed, aid={}, expected_version=1", id)
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
+}
+
+// FR6.3 / AC2.3.4 / BR3.1: keep_snapshot_count = Some(n) でスナップショット付き更新を繰り返すと、
+// プレイメージが履歴行として書かれ、保持フックが新しい順に n 件残して剪定する。
+// AC2.3.3 / BR2.3: 現行行・履歴行の payload は純ドメイン内容のみ（version 等の複製キーを含まない）
+#[tokio::test]
+async fn test_event_store_on_bigtable_prunes_snapshot_history() {
+  init_tracing();
+
+  let node = bigtable_emulator().await;
+  let port = node
+    .get_host_port_ipv4(8086)
+    .await
+    .expect("Failed to get Bigtable port");
+  let (client, store) = connect_store(port).await;
+  let mut store = store.with_keep_snapshot_count(Some(2)).expect("Some(2) is valid");
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  store
+    .persist_event_and_snapshot(
+      EventEnvelope::new(id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST),
+      user_account.clone(),
+      0,
+    )
+    .await
+    .expect("creation failed");
+
+  // スナップショット付き更新 × 3（プレイメージは seq_nr = 1, 2, 3 の 3 件生まれる）
+  let mut state = user_account;
+  for (seq_nr, name) in [(2_usize, "history-1"), (3, "history-2"), (4, "history-3")] {
+    let event = state.rename(name).unwrap();
+    store
+      .persist_event_and_snapshot(
+        EventEnvelope::new(id.clone(), seq_nr, Utc::now(), event).with_manifest(RENAMED_MANIFEST),
+        state.clone(),
+        seq_nr - 1,
+      )
+      .await
+      .expect("update failed");
+  }
+
+  // 剪定後の履歴行は新しい順に 2 件（プレイメージ seq_nr = 2, 3）だけが残る
+  let history_keys = scan_history_row_keys(&client, &id).await;
+  assert_eq!(history_keys, vec![history_row_key(&id, 2), history_row_key(&id, 3)]);
+
+  // 現行行は最新状態のまま（剪定は履歴行のみに作用する）
+  let snapshot = store
+    .get_latest_snapshot_by_id(&id)
+    .await
+    .unwrap()
+    .expect("snapshot must exist");
+  assert_eq!(snapshot.version(), 4);
+  assert_eq!(snapshot.seq_nr(), 4);
+  assert_eq!(snapshot.aggregate().name, "history-3");
+
+  // AC2.3.3: 現行行 payload は純ドメイン内容のみ（version / seq_nr / last_updated_at の複製なし）
+  let current_payload = read_snapshot_cell(&client, snapshot_row_key(&id), b"payload")
+    .await
+    .expect("current payload cell must exist");
+  let current_json: serde_json::Value = serde_json::from_slice(&current_payload).unwrap();
+  let expected_current = UserAccount {
+    id: id.clone(),
+    name: "history-3".to_string(),
+  };
+  assert_eq!(current_json, serde_json::to_value(&expected_current).unwrap());
+
+  // 履歴行（プレイメージ seq_nr = 3）の payload も純ドメイン内容のみで、更新前の状態を保持する
+  let history_payload = read_snapshot_cell(&client, history_row_key(&id, 3), b"payload")
+    .await
+    .expect("history payload cell must exist");
+  let history_json: serde_json::Value = serde_json::from_slice(&history_payload).unwrap();
+  let expected_history = UserAccount {
+    id: id.clone(),
+    name: "history-2".to_string(),
+  };
+  assert_eq!(history_json, serde_json::to_value(&expected_history).unwrap());
+}
+
+// BR3.1 / AC2.3.4: keep_snapshot_count = None（既定）は履歴行を書かず剪定もしない
+// （剪定なし設定に書込み増幅を持ち込まない — 現行挙動との互換）
+#[tokio::test]
+async fn test_event_store_on_bigtable_without_keep_snapshot_count_writes_no_history() {
+  init_tracing();
+
+  let node = bigtable_emulator().await;
+  let port = node
+    .get_host_port_ipv4(8086)
+    .await
+    .expect("Failed to get Bigtable port");
+  let (client, mut store) = connect_store(port).await;
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  store
+    .persist_event_and_snapshot(
+      EventEnvelope::new(id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST),
+      user_account.clone(),
+      0,
+    )
+    .await
+    .expect("creation failed");
+
+  let mut state = user_account;
+  for (seq_nr, name) in [(2_usize, "no-history-1"), (3, "no-history-2")] {
+    let event = state.rename(name).unwrap();
+    store
+      .persist_event_and_snapshot(
+        EventEnvelope::new(id.clone(), seq_nr, Utc::now(), event).with_manifest(RENAMED_MANIFEST),
+        state.clone(),
+        seq_nr - 1,
+      )
+      .await
+      .expect("update failed");
+  }
+
+  let history_keys = scan_history_row_keys(&client, &id).await;
+  assert!(
+    history_keys.is_empty(),
+    "no history rows must be written when keep_snapshot_count is None"
+  );
 }

--- a/lib/src/event_store_for_dynamodb.rs
+++ b/lib/src/event_store_for_dynamodb.rs
@@ -8,31 +8,57 @@ use aws_sdk_dynamodb::operation::transact_write_items::{TransactWriteItemsError,
 use aws_sdk_dynamodb::primitives::Blob;
 use aws_sdk_dynamodb::types::{AttributeValue, DeleteRequest, Put, Select, TransactWriteItem, Update, WriteRequest};
 use aws_sdk_dynamodb::Client;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tracing::Instrument;
 
-use crate::event_store_backend::{SnapshotEnvelope, SnapshotMaintenance, StorageBackend};
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
+use crate::event_store_backend::{SnapshotMaintenance, StorageBackend};
 use crate::generic_event_store::GenericEventStore;
 use crate::key_resolver::{DefaultKeyResolver, KeyResolver};
 use crate::serializer::{EventSerializer, SnapshotSerializer};
 use crate::types::{
-  format_optimistic_lock_message, Aggregate, AggregateId, Event, EventStore, EventStoreReadError, EventStoreWriteError,
+  format_optimistic_lock_message, AggregateId, EventStore, EventStoreReadError, EventStoreWriteError,
 };
 
-#[derive(Clone, Debug)]
-pub struct EventStoreForDynamoDB<AID, A, E>
+// FR6.1 / FR6.5: DynamoDB バックエンドの v3 封筒化。封筒⇔属性の 1:1 マッピング（AC2.1.1）、
+// TransactWriteItems + 条件式による原子的 CAS の現行維持（BR1.1 / P7 / NFR4.3）、条件付き
+// 履歴 Put + 剪定フックによる保持ポリシー（BR3.1）を StorageBackend + GenericEventStore の
+// 2 層委譲構造の上に実装する。
+
+// BR2.4: current スナップショット項目の skey は seq_nr=0 マーカーで解決する（キー設計の現行維持）。
+// このマーカーは物理キーの解決だけに使い、seq_nr 属性の実値（event.seq_nr()）とは混用しない。
+const CURRENT_SNAPSHOT_SKEY_MARKER: usize = 0;
+
+/// Event Store for Amazon DynamoDB
+pub struct EventStoreForDynamoDB<AID, A, P>
 where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
-  inner: GenericEventStore<AID, A, E, DynamoDbBackend<AID, A, E>>,
+  AID: AggregateId, {
+  inner: GenericEventStore<AID, A, P, DynamoDbBackend<AID, A, P>>,
 }
 
-impl<AID, A, E> EventStoreForDynamoDB<AID, A, E>
+// P2(U1): derive は型パラメータ（A / P）へ Debug / Clone 境界を課すため手動 impl とし、
+// payload への要求を実フィールド由来のものに限定する（BR1.6 の最小境界維持）
+impl<AID: AggregateId, A, P> Debug for EventStoreForDynamoDB<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("EventStoreForDynamoDB").finish()
+  }
+}
+
+impl<AID: AggregateId, A, P> Clone for EventStoreForDynamoDB<AID, A, P> {
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+    }
+  }
+}
+
+impl<AID, A, P> EventStoreForDynamoDB<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   pub fn new(
     client: Client,
@@ -55,11 +81,18 @@ where
     }
   }
 
-  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Self {
-    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count);
-    self
+  /// 保持するスナップショット履歴数を設定する。
+  ///
+  /// BR4.1(U1) / P3: 検証（`Some(0)` の拒否）は `GenericEventStore` 側の 1 箇所で行い、
+  /// このラッパーは Result を素通しする。
+  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Result<Self, EventStoreWriteError> {
+    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count)?;
+    Ok(self)
   }
 
+  /// 履歴スナップショットの保持期限を設定する。
+  ///
+  /// `with_keep_snapshot_count` と併用時のみ効果を持つ（`SnapshotMaintenance` の現行契約）。
   pub fn with_delete_ttl(mut self, delete_ttl: Option<Duration>) -> Self {
     self.inner = self.inner.with_delete_ttl(delete_ttl);
     self
@@ -70,7 +103,7 @@ where
     self
   }
 
-  pub fn with_event_serializer(mut self, serializer: Arc<dyn EventSerializer<E>>) -> Self {
+  pub fn with_event_serializer(mut self, serializer: Arc<dyn EventSerializer<P>>) -> Self {
     self.inner.backend_mut().set_event_serializer(serializer);
     self
   }
@@ -86,29 +119,40 @@ where
 }
 
 #[async_trait]
-impl<AID, A, E> EventStore for EventStoreForDynamoDB<AID, A, E>
+impl<AID, A, P> EventStore for EventStoreForDynamoDB<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
-  type AG = A;
+  type A = A;
   type AID = AID;
-  type EV = E;
+  type P = P;
 
-  async fn persist_event(&mut self, event: &Self::EV, version: usize) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event(event, version).await
+  async fn persist_event(
+    &mut self,
+    event: EventEnvelope<Self::AID, Self::P>,
+    expected_version: usize,
+  ) -> Result<(), EventStoreWriteError> {
+    self.inner.persist_event(event, expected_version).await
   }
 
   async fn persist_event_and_snapshot(
     &mut self,
-    event: &Self::EV,
-    aggregate: &Self::AG,
+    event: EventEnvelope<Self::AID, Self::P>,
+    aggregate: Self::A,
+    expected_version: usize,
   ) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event_and_snapshot(event, aggregate).await
+    self
+      .inner
+      .persist_event_and_snapshot(event, aggregate, expected_version)
+      .await
   }
 
-  async fn get_latest_snapshot_by_id(&self, aid: &Self::AID) -> Result<Option<Self::AG>, EventStoreReadError> {
+  async fn get_latest_snapshot_by_id(
+    &self,
+    aid: &Self::AID,
+  ) -> Result<Option<SnapshotEnvelope<Self::A>>, EventStoreReadError> {
     self.inner.get_latest_snapshot_by_id(aid).await
   }
 
@@ -116,17 +160,14 @@ where
     &self,
     aid: &Self::AID,
     seq_nr: usize,
-  ) -> Result<Vec<Self::EV>, EventStoreReadError> {
+  ) -> Result<Vec<EventEnvelope<Self::AID, Self::P>>, EventStoreReadError> {
     self.inner.get_events_by_id_since_seq_nr(aid, seq_nr).await
   }
 }
 
-#[derive(Clone, Debug)]
-struct DynamoDbBackend<AID, A, E>
+struct DynamoDbBackend<AID, A, P>
 where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
+  AID: AggregateId, {
   client: Client,
   journal_table_name: String,
   journal_aid_index_name: String,
@@ -134,15 +175,38 @@ where
   snapshot_aid_index_name: String,
   shard_count: u64,
   key_resolver: Arc<dyn KeyResolver<ID = AID>>,
-  event_serializer: Arc<dyn EventSerializer<E>>,
+  event_serializer: Arc<dyn EventSerializer<P>>,
   snapshot_serializer: Arc<dyn SnapshotSerializer<A>>,
 }
 
-impl<AID, A, E> DynamoDbBackend<AID, A, E>
+// P2(U1): derive は A / P へ Debug 境界を課すため手動 impl とする（内部構成は表示しない）
+impl<AID: AggregateId, A, P> Debug for DynamoDbBackend<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("DynamoDbBackend").finish()
+  }
+}
+
+impl<AID: AggregateId, A, P> Clone for DynamoDbBackend<AID, A, P> {
+  fn clone(&self) -> Self {
+    Self {
+      client: self.client.clone(),
+      journal_table_name: self.journal_table_name.clone(),
+      journal_aid_index_name: self.journal_aid_index_name.clone(),
+      snapshot_table_name: self.snapshot_table_name.clone(),
+      snapshot_aid_index_name: self.snapshot_aid_index_name.clone(),
+      shard_count: self.shard_count,
+      key_resolver: Arc::clone(&self.key_resolver),
+      event_serializer: Arc::clone(&self.event_serializer),
+      snapshot_serializer: Arc::clone(&self.snapshot_serializer),
+    }
+  }
+}
+
+impl<AID, A, P> DynamoDbBackend<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   fn new(
     client: Client,
@@ -169,7 +233,7 @@ where
     self.key_resolver = key_resolver;
   }
 
-  fn set_event_serializer(&mut self, serializer: Arc<dyn EventSerializer<E>>) {
+  fn set_event_serializer(&mut self, serializer: Arc<dyn EventSerializer<P>>) {
     self.event_serializer = serializer;
   }
 
@@ -185,9 +249,27 @@ where
     self.key_resolver.resolve_sort_key(id, seq_nr)
   }
 
-  fn put_snapshot(&self, event: &E, seq_nr: usize, aggregate: &A) -> Result<Put, EventStoreWriteError> {
+  fn current_snapshot_skey(&self, id: &AID) -> String {
+    self.resolve_skey(id, CURRENT_SNAPSHOT_SKEY_MARKER)
+  }
+
+  /// スナップショット項目の Put を構築する。
+  ///
+  /// BR2.4 / FR3.1 / FR3.2: version は明示値（create = 1、update = expected_version + 1）で
+  /// 受け取り、seq_nr 属性には封筒の実値（`event.seq_nr()`）を書く。`skey_seq_nr` は物理キーの
+  /// 解決のみに使い（current = マーカー 0、履歴 = event.seq_nr() 由来）、属性値には流用しない
+  /// （旧実装の skey 用引数の属性流用と `aggregate.version()` 導出の廃止）。
+  /// NFR2.4: 封筒の分解は公開アクセサのみで行う。
+  fn put_snapshot(
+    &self,
+    event: &EventEnvelope<AID, P>,
+    skey_seq_nr: usize,
+    version: usize,
+    aggregate: &A,
+  ) -> Result<Put, EventStoreWriteError> {
     let pkey = self.resolve_pkey(event.aggregate_id());
-    let skey = self.resolve_skey(event.aggregate_id(), seq_nr);
+    let skey = self.resolve_skey(event.aggregate_id(), skey_seq_nr);
+    // BR2.3 / FR4.2 / AC2.3.3: payload は純ドメイン内容のみ（メタデータ注入つき直列化の廃止）
     let payload = self.snapshot_serializer.serialize(aggregate)?;
     Put::builder()
       .table_name(self.snapshot_table_name.clone())
@@ -195,8 +277,8 @@ where
       .item("skey", AttributeValue::S(skey))
       .item("payload", AttributeValue::B(Blob::new(payload)))
       .item("aid", AttributeValue::S(event.aggregate_id().to_string()))
-      .item("seq_nr", AttributeValue::N(seq_nr.to_string()))
-      .item("version", AttributeValue::N(aggregate.version().to_string()))
+      .item("seq_nr", AttributeValue::N(event.seq_nr().to_string()))
+      .item("version", AttributeValue::N(version.to_string()))
       .item("ttl", AttributeValue::N("0".to_string()))
       .item(
         "last_updated_at",
@@ -207,15 +289,21 @@ where
       .map_err(|err| EventStoreWriteError::IOError(err.into()))
   }
 
+  /// current スナップショット項目の条件付き Update を構築する。
+  ///
+  /// BR1.1 / P7: 条件式 `#version=:before_version` が唯一の競合判定点（現行維持）。
+  /// BR2.4: version（expected_version + 1 の明示値）と last_updated_at は常時更新し、
+  /// seq_nr / payload はスナップショット付き更新（aggregate あり）のときだけ実値
+  /// （`event.seq_nr()`）で更新する。イベントのみ更新（aggregate なし）では集約状態が
+  /// 変わらないため据え置く。
   fn update_snapshot(
     &self,
-    event: &E,
-    seq_nr: usize,
+    event: &EventEnvelope<AID, P>,
     expected_version: usize,
     aggregate: Option<&A>,
   ) -> Result<Update, EventStoreWriteError> {
     let pkey = self.resolve_pkey(event.aggregate_id());
-    let skey = self.resolve_skey(event.aggregate_id(), seq_nr);
+    let skey = self.current_snapshot_skey(event.aggregate_id());
     let mut update_snapshot = Update::builder()
       .table_name(self.snapshot_table_name.clone())
       .update_expression("SET #version=:after_version, #last_updated_at=:last_updated_at")
@@ -231,6 +319,7 @@ where
       )
       .condition_expression("#version=:before_version");
     if let Some(aggregate) = aggregate {
+      // BR2.3 / AC2.3.3: payload は純ドメイン内容のみ
       let payload = self.snapshot_serializer.serialize(aggregate)?;
       update_snapshot = update_snapshot
         .update_expression(
@@ -238,7 +327,7 @@ where
         )
         .expression_attribute_names("#seq_nr", "seq_nr")
         .expression_attribute_names("#payload", "payload")
-        .expression_attribute_values(":seq_nr", AttributeValue::N(seq_nr.to_string()))
+        .expression_attribute_values(":seq_nr", AttributeValue::N(event.seq_nr().to_string()))
         .expression_attribute_values(":payload", AttributeValue::B(Blob::new(payload)));
     }
     update_snapshot
@@ -246,11 +335,17 @@ where
       .map_err(|err| EventStoreWriteError::IOError(err.into()))
   }
 
-  fn put_journal(&self, event: &E) -> Result<Put, EventStoreWriteError> {
+  /// journal へ封筒 1 件を 1 アイテムとして書く Put を構築する。
+  ///
+  /// BR2.1 / FR6.1 / AC2.1.1: 封筒メタデータ 4 点（aid / seq_nr / occurred_at / manifest）+
+  /// payload を属性へ 1:1 で書く。manifest 属性は v3 新設で、省略時は空文字列がそのまま
+  /// 格納される（U1 BR1.2 のラウンドトリップ — AC5.1.1）。payload の直列化対象は
+  /// `event.payload()` のみ（BR2.3 — イベント丸ごと直列化の廃止）。
+  fn put_journal(&self, event: &EventEnvelope<AID, P>) -> Result<Put, EventStoreWriteError> {
     let pkey = self.resolve_pkey(event.aggregate_id());
     let skey = self.resolve_skey(event.aggregate_id(), event.seq_nr());
-    let payload = self.event_serializer.serialize(event)?;
-    let occurred_at = event.occurred_at().timestamp_millis().to_string();
+    let payload = self.event_serializer.serialize(event.payload())?;
+    let occurred_at = format_occurred_at(event.occurred_at())?;
     Put::builder()
       .table_name(self.journal_table_name.clone())
       .item("pkey", AttributeValue::S(pkey))
@@ -259,8 +354,35 @@ where
       .item("seq_nr", AttributeValue::N(event.seq_nr().to_string()))
       .item("payload", AttributeValue::B(Blob::new(payload)))
       .item("occurred_at", AttributeValue::N(occurred_at))
+      .item("manifest", AttributeValue::S(event.manifest().to_string()))
       .build()
       .map_err(|err| EventStoreWriteError::IOError(err.into()))
+  }
+
+  /// journal アイテムの属性群からイベント封筒を再構成する。
+  ///
+  /// BR2.2 / AC4.1.1: aid / seq_nr / occurred_at / manifest / payload の全属性を使い、
+  /// 属性欠落は破損データとして読取エラーにする（payload 単独 deserialize の廃止 — FR5.1）。
+  /// NFR2.4: 封筒の構築は `EventEnvelope::new` + `with_manifest` の公開ビルダーのみで行う。
+  fn event_envelope_from_item(
+    &self,
+    aid: &AID,
+    item: &HashMap<String, AttributeValue>,
+  ) -> Result<EventEnvelope<AID, P>, EventStoreReadError> {
+    let stored_aid = required_string(item, "aid", "journal")?;
+    if stored_aid != aid.to_string() {
+      return Err(EventStoreReadError::OtherError(format!(
+        "journal aid attribute does not match the requested aggregate: aid={}",
+        aid
+      )));
+    }
+    let seq_nr = parse_usize_attr(item, "seq_nr", "journal")?;
+    let occurred_at = parse_occurred_at(required_number(item, "occurred_at", "journal")?)?;
+    let manifest = required_string(item, "manifest", "journal")?.to_string();
+    let payload = self
+      .event_serializer
+      .deserialize(required_blob(item, "payload", "journal")?)?;
+    Ok(EventEnvelope::new(aid.clone(), seq_nr, occurred_at, payload).with_manifest(manifest))
   }
 
   async fn maintain_snapshots(
@@ -268,6 +390,8 @@ where
     aggregate_id: &AID,
     maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError> {
+    // BR3.1 / FR6.3: keep_snapshot_count = None は剪定しない（履歴 Put も行われないため
+    // 対象が存在しない）。Some(0) は U1 BR4.1 のビルダー拒否によりここへ到達しない
     let keep_snapshot_count = match maintenance.keep_snapshot_count {
       Some(count) if count > 0 => count,
       _ => return Ok(()),
@@ -286,6 +410,7 @@ where
     aggregate_id: &AID,
     keep_snapshot_count: usize,
   ) -> Result<(), EventStoreWriteError> {
+    // BR3.1: excess = 件数 −（keep + 1）の現行意味論を維持する（current 1 + 履歴 n 件）
     let snapshot_count = self
       .get_snapshot_count(aggregate_id)
       .await
@@ -295,7 +420,7 @@ where
       return Ok(());
     }
     let keys = self
-      .get_last_snapshot_keys(aggregate_id, excess_count as i32)
+      .get_last_snapshot_keys(aggregate_id, excess_count)
       .await
       .map_err(|err| EventStoreWriteError::OtherError(err.to_string()))?;
     if keys.is_empty() {
@@ -304,17 +429,16 @@ where
     let request_items = keys
       .into_iter()
       .map(|(pkey, skey)| {
-        WriteRequest::builder()
-          .delete_request(
-            DeleteRequest::builder()
-              .key("pkey", AttributeValue::S(pkey))
-              .key("skey", AttributeValue::S(skey))
-              .build()
-              .unwrap(),
-          )
+        // BR4.1 / FR6.5 / P8: DeleteRequest ビルダーの build() Result もエラー写像し、
+        // panic 経路を残さない（同ファイルの Put ビルダーの map_err と同形）
+        let delete_request = DeleteRequest::builder()
+          .key("pkey", AttributeValue::S(pkey))
+          .key("skey", AttributeValue::S(skey))
           .build()
+          .map_err(|err| EventStoreWriteError::IOError(err.into()))?;
+        Ok(WriteRequest::builder().delete_request(delete_request).build())
       })
-      .collect::<Vec<_>>();
+      .collect::<Result<Vec<_>, EventStoreWriteError>>()?;
     let result = self
       .client
       .batch_write_item()
@@ -343,7 +467,7 @@ where
       return Ok(());
     }
     let keys = self
-      .get_last_snapshot_keys(aggregate_id, excess_count as i32)
+      .get_last_snapshot_keys(aggregate_id, excess_count)
       .await
       .map_err(|err| EventStoreWriteError::OtherError(err.to_string()))?;
     if keys.is_empty() {
@@ -387,18 +511,27 @@ where
     }
   }
 
-  async fn get_last_snapshot_keys(&self, aid: &AID, limit: i32) -> Result<Vec<(String, String)>, EventStoreReadError> {
+  /// 剪定対象候補のスナップショット項目キーを seq_nr 降順で `limit` 件返す。
+  ///
+  /// BR2.4 で current 項目の seq_nr 属性が実値化されたため、旧実装の「seq_nr > 0」条件では
+  /// current 項目を候補から除外できない。候補を 1 件余分に取得し、current 項目
+  /// （skey マーカー 0）をコードで除外してから limit 件に切り詰める（走査順は現行維持 —
+  /// seq_nr 降順。BR3.1 の件数意味論は不変）。
+  async fn get_last_snapshot_keys(
+    &self,
+    aid: &AID,
+    limit: usize,
+  ) -> Result<Vec<(String, String)>, EventStoreReadError> {
+    let current_skey = self.current_snapshot_skey(aid);
     let response = self
       .client
       .query()
       .table_name(self.snapshot_table_name.clone())
       .index_name(self.snapshot_aid_index_name.clone())
-      .key_condition_expression("#aid = :aid AND #seq_nr > :seq_nr")
+      .key_condition_expression("#aid = :aid")
       .expression_attribute_names("#aid", "aid")
-      .expression_attribute_names("#seq_nr", "seq_nr")
       .expression_attribute_values(":aid", AttributeValue::S(aid.to_string()))
-      .expression_attribute_values(":seq_nr", AttributeValue::N("0".to_string()))
-      .limit(limit)
+      .limit((limit + 1) as i32)
       .scan_index_forward(false)
       .send()
       .await;
@@ -411,10 +544,13 @@ where
             let pkey = item.get("pkey").and_then(|v| v.as_s().ok()).cloned();
             let skey = item.get("skey").and_then(|v| v.as_s().ok()).cloned();
             if let (Some(pkey), Some(skey)) = (pkey, skey) {
-              keys.push((pkey, skey));
+              if skey != current_skey {
+                keys.push((pkey, skey));
+              }
             }
           }
         }
+        keys.truncate(limit);
         Ok(keys)
       }
     }
@@ -422,43 +558,50 @@ where
 }
 
 #[async_trait]
-impl<AID, A, E> StorageBackend<AID, A, E> for DynamoDbBackend<AID, A, E>
+impl<AID, A, P> StorageBackend<AID, A, P> for DynamoDbBackend<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   async fn fetch_latest_snapshot(&self, aid: &AID) -> Result<Option<SnapshotEnvelope<A>>, EventStoreReadError> {
-    let item = match self.fetch_snapshot_items(aid).await? {
-      Some(item) => item,
-      None => return Ok(None),
+    // BR2.4 の帰結: current 項目の seq_nr 属性が実値化されたため、旧実装の「aid インデックスへの
+    // seq_nr = 0 Query」では current 項目を特定できない。主キー（pkey + skey マーカー 0）の
+    // GetItem で取得する。読取済み version を次回書込の expected_version に使うため（W4）、
+    // 自身の書込を読み戻せる強整合読取にする（GSI Query では選択不可能だった）
+    let pkey = self.resolve_pkey(aid);
+    let skey = self.current_snapshot_skey(aid);
+    let response = self
+      .client
+      .get_item()
+      .table_name(self.snapshot_table_name.clone())
+      .key("pkey", AttributeValue::S(pkey))
+      .key("skey", AttributeValue::S(skey))
+      .consistent_read(true)
+      .send()
+      .await;
+    let item = match response {
+      Err(err) => return Err(EventStoreReadError::IOError(err.into())),
+      Ok(response) => match response.item {
+        None => return Ok(None),
+        Some(item) => item,
+      },
     };
-    let payload_attr = item
-      .get("payload")
-      .and_then(|v| v.as_b().ok())
-      .ok_or_else(|| EventStoreReadError::OtherError("snapshot payload is missing".to_string()))?;
-    let version = item
-      .get("version")
-      .and_then(|v| v.as_n().ok())
-      .ok_or_else(|| EventStoreReadError::OtherError("snapshot version is missing".to_string()))?
-      .parse::<usize>()
-      .map_err(|err| EventStoreReadError::OtherError(err.to_string()))?;
-    let seq_nr = item
-      .get("seq_nr")
-      .and_then(|v| v.as_n().ok())
-      .and_then(|s| s.parse::<usize>().ok())
-      .unwrap_or_default();
-    let payload_bytes = payload_attr.clone().into_inner();
-    let mut aggregate = *self.snapshot_serializer.deserialize(&payload_bytes)?;
-    aggregate.set_version(version);
-    Ok(Some(SnapshotEnvelope {
-      aggregate,
-      seq_nr,
-      version,
-    }))
+    // FR4.3 / U1 BR2.5: 読取後の set_version 補正は存在しない — version / seq_nr は
+    // 属性値をそのまま封筒に載せて返す（属性欠落は破損データとして読取エラー）
+    let version = parse_usize_attr(&item, "version", "snapshot")?;
+    let seq_nr = parse_usize_attr(&item, "seq_nr", "snapshot")?;
+    let aggregate = self
+      .snapshot_serializer
+      .deserialize(required_blob(&item, "payload", "snapshot")?)?;
+    Ok(Some(SnapshotEnvelope::new(aggregate, seq_nr, version)))
   }
 
-  async fn fetch_events_since(&self, aid: &AID, seq_nr: usize) -> Result<Vec<E>, EventStoreReadError> {
+  async fn fetch_events_since(
+    &self,
+    aid: &AID,
+    seq_nr: usize,
+  ) -> Result<Vec<EventEnvelope<AID, P>>, EventStoreReadError> {
     let response = self
       .client
       .query()
@@ -474,15 +617,11 @@ where
     match response {
       Err(err) => Err(EventStoreReadError::IOError(err.into())),
       Ok(response) => {
-        let mut events = Vec::new();
-        if let Some(items) = response.items {
-          for item in items {
-            if let Some(payload) = item.get("payload").and_then(|v| v.as_b().ok()) {
-              let bytes = payload.clone().into_inner();
-              let event = *self.event_serializer.deserialize(&bytes)?;
-              events.push(event);
-            }
-          }
+        let items = response.items.unwrap_or_default();
+        let mut events = Vec::with_capacity(items.len());
+        for item in items {
+          // BR2.2: 各アイテムの属性群から封筒を再構成する（属性欠落は読取エラー）
+          events.push(self.event_envelope_from_item(aid, &item)?);
         }
         Ok(events)
       }
@@ -491,50 +630,62 @@ where
 
   async fn create_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: &A,
     maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError> {
+    // BR1.1 / P7 / NFR4.3: journal Put + current Put（+ 条件付き履歴 Put）を単一の
+    // TransactWriteItems に束ね、条件式 attribute_not_exists(pkey) AND attribute_not_exists(skey)
+    // を唯一の競合判定点にする（現行維持）
     let mut builder = self
       .client
       .transact_write_items()
       .transact_items(
         TransactWriteItem::builder()
-          .put(self.put_snapshot(event, 0, aggregate)?)
+          // W1: current 項目は version = 1（固定値）、seq_nr 属性 = event.seq_nr()（実値 — BR2.4）
+          .put(self.put_snapshot(event, CURRENT_SNAPSHOT_SKEY_MARKER, 1, aggregate)?)
           .build(),
       )
       .transact_items(TransactWriteItem::builder().put(self.put_journal(event)?).build());
     if maintenance.keep_snapshot_count.is_some() {
+      // BR3.1: keep_snapshot_count = Some(n) のときのみ履歴項目（skey / seq_nr は
+      // event.seq_nr() 由来）を同一トランザクションに含める（現行の条件付き 2 本目 Put の維持）
       builder = builder.transact_items(
         TransactWriteItem::builder()
-          .put(self.put_snapshot(event, aggregate.seq_nr(), aggregate)?)
+          .put(self.put_snapshot(event, event.seq_nr(), 1, aggregate)?)
           .build(),
       );
     }
     let result = builder.send().await;
-    write_error_handling(result, &event.aggregate_id().to_string(), aggregate.version())
+    // 新規作成の expected_version は 0（U1 の W1 規約）
+    write_error_handling(result, &event.aggregate_id().to_string(), 0)
   }
 
   async fn update_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: Option<&A>,
     expected_version: usize,
     maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError> {
+    // BR1.1 / P7: journal Put + current Update（条件式 #version=:before_version）を単一の
+    // TransactWriteItems に束ねる（現行維持）。不在集約への更新も同じ条件式の不成立として
+    // OptimisticLockError（actual なし — U1 リファレンス意味論）になる（AC2.2.1）
     let mut builder = self
       .client
       .transact_write_items()
       .transact_items(
         TransactWriteItem::builder()
-          .update(self.update_snapshot(event, 0, expected_version, aggregate)?)
+          .update(self.update_snapshot(event, expected_version, aggregate)?)
           .build(),
       )
       .transact_items(TransactWriteItem::builder().put(self.put_journal(event)?).build());
     if let (Some(aggregate), Some(_)) = (aggregate, maintenance.keep_snapshot_count) {
+      // BR3.1 / BR2.4: 履歴項目は keep_snapshot_count = Some(n) かつスナップショット付き更新の
+      // ときのみ。skey / seq_nr 属性は event.seq_nr()、version は expected_version + 1 の明示値
       builder = builder.transact_items(
         TransactWriteItem::builder()
-          .put(self.put_snapshot(event, aggregate.seq_nr(), aggregate)?)
+          .put(self.put_snapshot(event, event.seq_nr(), expected_version + 1, aggregate)?)
           .build(),
       );
     }
@@ -543,40 +694,14 @@ where
   }
 
   async fn on_event_persisted(&self, aid: &AID, maintenance: &SnapshotMaintenance) -> Result<(), EventStoreWriteError> {
+    // BR3.1 / FR6.3 / AC2.3.4: 保持ポリシーの実行点（ttl 更新 / 削除の 2 モード — 現行維持）
     self.maintain_snapshots(aid, maintenance).await
   }
 }
 
-impl<AID, A, E> DynamoDbBackend<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
-  async fn fetch_snapshot_items(
-    &self,
-    aid: &AID,
-  ) -> Result<Option<HashMap<String, AttributeValue>>, EventStoreReadError> {
-    let response = self
-      .client
-      .query()
-      .table_name(self.snapshot_table_name.clone())
-      .index_name(self.snapshot_aid_index_name.clone())
-      .key_condition_expression("#aid = :aid AND #seq_nr = :seq_nr")
-      .expression_attribute_names("#aid", "aid")
-      .expression_attribute_names("#seq_nr", "seq_nr")
-      .expression_attribute_values(":aid", AttributeValue::S(aid.to_string()))
-      .expression_attribute_values(":seq_nr", AttributeValue::N("0".to_string()))
-      .limit(1)
-      .send()
-      .await;
-    match response {
-      Err(err) => Err(EventStoreReadError::IOError(err.into())),
-      Ok(response) => Ok(response.items.and_then(|mut items| items.pop())),
-    }
-  }
-}
-
+// BR1.1 / BR5.1 / P9: TransactWriteItems の失敗写像点。条件不成立（TransactionCanceledException）
+// のみ OptimisticLockError（統一書式 — 現行維持）とし、その他の SDK エラーは書式化展開ゼロで
+// IOError のソースとして保持する（資格情報・エンドポイント・テーブル名を展開しない — NFR3.7）
 fn write_error_handling(
   result: Result<TransactWriteItemsOutput, SdkError<TransactWriteItemsError>>,
   aid: &str,
@@ -598,4 +723,82 @@ fn write_error_handling(
       error => Err(EventStoreWriteError::IOError(error.into())),
     },
   }
+}
+
+// FR1.4 / U1 BR1.3 / C3: occurred_at はドメイン供給値のまま保存・読出しする。現行の epoch millis
+// 格納ではサブミリ秒精度が失われ供給値の完全往復（共有シナリオの occurred_at 同値 assert）を
+// 満たせないため、N 属性の epoch nanos で格納する（U3 申し送りの精度要件。entities.md の
+// 論理型 N は維持し、精度のみ millis → nanos に置換）。i64 nanos の表現範囲外
+// （およそ西暦 1677〜2262 年の外）は黙って切り詰めずエラーで拒否する（NFR3.6 — fail fast）
+fn format_occurred_at(occurred_at: &DateTime<Utc>) -> Result<String, EventStoreWriteError> {
+  occurred_at
+    .timestamp_nanos_opt()
+    .map(|nanos| nanos.to_string())
+    .ok_or_else(|| EventStoreWriteError::OtherError("occurred_at is out of the epoch-nanos range".to_string()))
+}
+
+fn parse_occurred_at(text: &str) -> Result<DateTime<Utc>, EventStoreReadError> {
+  text
+    .parse::<i64>()
+    .map(DateTime::from_timestamp_nanos)
+    .map_err(|err| EventStoreReadError::OtherError(err.to_string()))
+}
+
+// BR2.2 / P9: 属性欠落・型不一致は破損データとして読取エラーにする
+// （メッセージはアイテム種別と属性名のみで、値・テーブル名は展開しない）
+fn required_attr<'a>(
+  item: &'a HashMap<String, AttributeValue>,
+  name: &'static str,
+  item_kind: &'static str,
+) -> Result<&'a AttributeValue, EventStoreReadError> {
+  item
+    .get(name)
+    .ok_or_else(|| EventStoreReadError::OtherError(format!("{} item attribute is missing: {}", item_kind, name)))
+}
+
+fn attr_type_error(name: &str, item_kind: &str) -> EventStoreReadError {
+  EventStoreReadError::OtherError(format!("{} item attribute has an unexpected type: {}", item_kind, name))
+}
+
+fn required_string<'a>(
+  item: &'a HashMap<String, AttributeValue>,
+  name: &'static str,
+  item_kind: &'static str,
+) -> Result<&'a str, EventStoreReadError> {
+  required_attr(item, name, item_kind)?
+    .as_s()
+    .map(|s| s.as_str())
+    .map_err(|_| attr_type_error(name, item_kind))
+}
+
+fn required_blob<'a>(
+  item: &'a HashMap<String, AttributeValue>,
+  name: &'static str,
+  item_kind: &'static str,
+) -> Result<&'a [u8], EventStoreReadError> {
+  required_attr(item, name, item_kind)?
+    .as_b()
+    .map(|b| b.as_ref())
+    .map_err(|_| attr_type_error(name, item_kind))
+}
+
+fn required_number<'a>(
+  item: &'a HashMap<String, AttributeValue>,
+  name: &'static str,
+  item_kind: &'static str,
+) -> Result<&'a str, EventStoreReadError> {
+  required_attr(item, name, item_kind)?
+    .as_n()
+    .map(|s| s.as_str())
+    .map_err(|_| attr_type_error(name, item_kind))
+}
+
+fn parse_usize_attr(
+  item: &HashMap<String, AttributeValue>,
+  name: &'static str,
+  item_kind: &'static str,
+) -> Result<usize, EventStoreReadError> {
+  required_number(item, name, item_kind)?
+    .parse::<usize>()
+    .map_err(|err| EventStoreReadError::OtherError(err.to_string()))
 }

--- a/lib/src/event_store_for_dynamodb_test.rs
+++ b/lib/src/event_store_for_dynamodb_test.rs
@@ -1,65 +1,408 @@
+use std::collections::HashMap;
+
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::Client;
+use chrono::Utc;
 use event_store_adapter_test_utils_rs::docker::dynamodb_local;
 use event_store_adapter_test_utils_rs::dynamodb::{
   create_client, create_journal_table, create_snapshot_table, wait_table,
 };
 use event_store_adapter_test_utils_rs::id_generator::id_generate;
-use std::env;
-use std::thread::sleep;
-use std::time::Duration as StdDuration;
+use tokio::time::{sleep, Duration as TokioDuration};
 
+use crate::event_envelope::EventEnvelope;
 use crate::event_store_for_dynamodb::EventStoreForDynamoDB;
-use crate::event_store_test_support::{exercise_user_account_flow, init_tracing, UserAccountId};
+use crate::event_store_test_support::{
+  assert_optimistic_lock_message_format, exercise_user_account_flow, find_by_id, init_tracing, UserAccount,
+  UserAccountEvent, UserAccountId, CREATED_MANIFEST, RENAMED_MANIFEST,
+};
+use crate::key_resolver::{DefaultKeyResolver, KeyResolver};
+use crate::types::{EventStore, EventStoreReadError, EventStoreWriteError};
 
-#[tokio::test]
-async fn test_event_store_on_dynamodb() {
-  env::set_var("RUST_LOG", "event_store_adapter_rs=debug");
-  init_tracing();
+const JOURNAL_TABLE: &str = "journal";
+const JOURNAL_AID_INDEX: &str = "journal-aid-index";
+const SNAPSHOT_TABLE: &str = "snapshot";
+const SNAPSHOT_AID_INDEX: &str = "snapshot-aid-index";
+const SHARD_COUNT: u64 = 64;
 
-  let dynamodb_node = dynamodb_local().await;
-  let port = dynamodb_node
-    .get_host_port_ipv4(4566)
-    .await
-    .expect("Failed to get port");
+type UserAccountStore = EventStoreForDynamoDB<UserAccountId, UserAccount, UserAccountEvent>;
 
-  let test_time_factor = env::var("TEST_TIME_FACTOR")
-    .unwrap_or("1".to_string())
-    .parse::<f32>()
-    .unwrap();
+fn test_time_factor() -> f32 {
+  std::env::var("TEST_TIME_FACTOR")
+    .ok()
+    .and_then(|value| value.parse::<f32>().ok())
+    .unwrap_or(1.0)
+}
 
-  sleep(StdDuration::from_millis((1000f32 * test_time_factor) as u64));
+/// LocalStack へ接続し、テーブルを作成してストアを構築する（1 テストにつき独立したコンテナ）。
+async fn connect_store(port: u16) -> (Client, UserAccountStore) {
+  let wait = TokioDuration::from_millis((1000f32 * test_time_factor()) as u64);
+  sleep(wait).await;
 
   let client = create_client(port);
-
-  let journal_table_name = "journal";
-  let journal_aid_index_name = "journal-aid-index";
-  let _ = create_journal_table(&client, journal_table_name, journal_aid_index_name).await;
-
-  let snapshot_table_name = "snapshot";
-  let snapshot_aid_index_name = "snapshot-aid-index";
-  let _ = create_snapshot_table(&client, snapshot_table_name, snapshot_aid_index_name).await;
-
-  while !(wait_table(&client, journal_table_name).await) {
-    sleep(StdDuration::from_millis((1000f32 * test_time_factor) as u64));
+  let _ = create_journal_table(&client, JOURNAL_TABLE, JOURNAL_AID_INDEX).await;
+  let _ = create_snapshot_table(&client, SNAPSHOT_TABLE, SNAPSHOT_AID_INDEX).await;
+  while !(wait_table(&client, JOURNAL_TABLE).await) {
+    sleep(wait).await;
   }
-  while !(wait_table(&client, snapshot_table_name).await) {
-    sleep(StdDuration::from_millis((1000f32 * test_time_factor) as u64));
+  while !(wait_table(&client, SNAPSHOT_TABLE).await) {
+    sleep(wait).await;
   }
 
-  let mut event_store = EventStoreForDynamoDB::new(
+  let store = UserAccountStore::new(
     client.clone(),
-    journal_table_name.to_string(),
-    journal_aid_index_name.to_string(),
-    snapshot_table_name.to_string(),
-    snapshot_aid_index_name.to_string(),
-    64,
-  )
-  .with_keep_snapshot_count(Some(1))
-  .with_delete_ttl(Some(chrono::Duration::seconds(5)));
+    JOURNAL_TABLE.to_string(),
+    JOURNAL_AID_INDEX.to_string(),
+    SNAPSHOT_TABLE.to_string(),
+    SNAPSHOT_AID_INDEX.to_string(),
+    SHARD_COUNT,
+  );
+  (client, store)
+}
 
-  let id_value = id_generate();
-  let id = UserAccountId::new(id_value.to_string());
+// バックエンドのキースキーム（DefaultKeyResolver の sort key）の複製。
+// スナップショット項目の物理配置（current = skey マーカー 0 / 履歴 = skey seq_nr 修飾）を
+// 白箱検証するために使う
+fn snapshot_skey(id: &UserAccountId, seq_nr: usize) -> String {
+  let resolver = DefaultKeyResolver::<UserAccountId>::default();
+  resolver.resolve_sort_key(id, seq_nr)
+}
+
+fn current_snapshot_skey(id: &UserAccountId) -> String {
+  snapshot_skey(id, 0)
+}
+
+/// snapshot テーブルの対象集約の全アイテムを (skey, payload) で返す（剪定結果の白箱検証用）。
+async fn scan_snapshot_items(client: &Client, id: &UserAccountId) -> HashMap<String, Vec<u8>> {
+  let response = client
+    .query()
+    .table_name(SNAPSHOT_TABLE)
+    .index_name(SNAPSHOT_AID_INDEX)
+    .key_condition_expression("#aid = :aid")
+    .expression_attribute_names("#aid", "aid")
+    .expression_attribute_values(":aid", AttributeValue::S(id.to_string()))
+    .send()
+    .await
+    .expect("query failed");
+  response
+    .items
+    .unwrap_or_default()
+    .into_iter()
+    .map(|item| {
+      let skey = item
+        .get("skey")
+        .and_then(|value| value.as_s().ok())
+        .cloned()
+        .expect("skey attribute must exist");
+      let payload = item
+        .get("payload")
+        .and_then(|value| value.as_b().ok())
+        .cloned()
+        .expect("payload attribute must exist")
+        .into_inner();
+      (skey, payload)
+    })
+    .collect()
+}
+
+fn renamed_envelope(
+  id: &UserAccountId,
+  seq_nr: usize,
+  payload: UserAccountEvent,
+) -> EventEnvelope<UserAccountId, UserAccountEvent> {
+  EventEnvelope::new(id.clone(), seq_nr, Utc::now(), payload).with_manifest(RENAMED_MANIFEST)
+}
+
+// FR7.1 / C3 / AC5.1.1: 共有シナリオ（8 手順・封筒メタデータ往復 assert 含む）を無改変で green にする。
+// keep_snapshot_count + delete_ttl の組み合わせで ttl 更新方式の剪定経路も同時に通す（現行構成維持）
+#[tokio::test]
+async fn test_event_store_on_dynamodb() {
+  init_tracing();
+
+  let node = dynamodb_local().await;
+  let port = node.get_host_port_ipv4(4566).await.expect("Failed to get port");
+  let (_client, store) = connect_store(port).await;
+  let mut event_store = store
+    .with_keep_snapshot_count(Some(1))
+    .expect("Some(1) is valid")
+    .with_delete_ttl(Some(chrono::Duration::seconds(5)));
+
+  let id = UserAccountId::new(id_generate().to_string());
 
   exercise_user_account_flow(&mut event_store, &id)
     .await
     .expect("scenario failed");
+}
+
+// NFR4.1 / AC2.2.1 / BR1.1: 同時更新の競合パス — 同一 expected_version の並行更新 2 本のうち
+// 一方のみが成功し、他方は統一書式（許可キーのみ）の OptimisticLockError になる。
+// TransactWriteItems の条件式が唯一の競合判定点であることの実機検証（P7）
+#[tokio::test]
+async fn test_event_store_on_dynamodb_concurrent_conflict_yields_optimistic_lock_error() {
+  init_tracing();
+
+  let node = dynamodb_local().await;
+  let port = node.get_host_port_ipv4(4566).await.expect("Failed to get port");
+  let (_client, store) = connect_store(port).await;
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  {
+    let mut writer = store.clone();
+    writer
+      .persist_event_and_snapshot(
+        EventEnvelope::new(id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST),
+        user_account,
+        0,
+      )
+      .await
+      .expect("creation failed");
+  }
+
+  let mut store_a = store.clone();
+  let mut store_b = store.clone();
+  let mut account_a = find_by_id(&store_a, &id).await.unwrap().unwrap();
+  let mut account_b = find_by_id(&store_b, &id).await.unwrap().unwrap();
+  let envelope_a = renamed_envelope(&id, account_a.seq_nr + 1, account_a.state.rename("conflict-a").unwrap());
+  let envelope_b = renamed_envelope(&id, account_b.seq_nr + 1, account_b.state.rename("conflict-b").unwrap());
+  let version_a = account_a.version;
+  let version_b = account_b.version;
+
+  let (result_a, result_b) = tokio::join!(
+    async move { store_a.persist_event(envelope_a, version_a).await },
+    async move { store_b.persist_event(envelope_b, version_b).await },
+  );
+
+  let err = match (result_a, result_b) {
+    (Err(err), Ok(())) | (Ok(()), Err(err)) => err,
+    (Ok(()), Ok(())) => panic!("exactly one concurrent write must win, but both succeeded"),
+    (Err(err_a), Err(err_b)) => panic!(
+      "exactly one concurrent write must win, but both failed: {:?} / {:?}",
+      err_a, err_b
+    ),
+  };
+  match err {
+    EventStoreWriteError::OptimisticLockError(message) => {
+      assert!(
+        message.starts_with(&format!("optimistic lock failed, aid={}, expected_version=1", id)),
+        "unexpected message: {}",
+        message
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
+}
+
+// AC2.2.2 / AC4.1.3 / BR5.1 / NFR3.7: 接続不能でも panic せず IOError 系の中立エラーが返り、
+// メッセージに接続文字列・テーブル名が展開されない（P9）。
+// 未使用ポートのエンドポイント指定で実現する（Docker 不要）
+#[tokio::test]
+async fn test_event_store_on_dynamodb_unreachable_endpoint_returns_io_error() {
+  init_tracing();
+
+  let client = create_client(1);
+  let mut store: UserAccountStore = EventStoreForDynamoDB::new(
+    client,
+    JOURNAL_TABLE.to_string(),
+    JOURNAL_AID_INDEX.to_string(),
+    SNAPSHOT_TABLE.to_string(),
+    SNAPSHOT_AID_INDEX.to_string(),
+    SHARD_COUNT,
+  );
+
+  let id = UserAccountId::new(id_generate().to_string());
+
+  // 読取経路（fetch_latest_snapshot の GetItem が接続不能）
+  let read_result = store.get_latest_snapshot_by_id(&id).await;
+  match read_result {
+    Err(EventStoreReadError::IOError(source)) => {
+      let message = source.to_string();
+      assert!(!message.contains("://"), "message must not contain connection strings");
+      assert!(
+        !message.contains(JOURNAL_TABLE) && !message.contains(SNAPSHOT_TABLE),
+        "message must not contain table names"
+      );
+    }
+    other => panic!("expected IOError, got {:?}", other),
+  }
+
+  // 書込経路（W1: create の TransactWriteItems が接続不能）
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  let write_result = store
+    .persist_event_and_snapshot(EventEnvelope::new(id.clone(), 1, Utc::now(), created), user_account, 0)
+    .await;
+  match write_result {
+    Err(EventStoreWriteError::IOError(source)) => {
+      let message = source.to_string();
+      assert!(!message.contains("://"), "message must not contain connection strings");
+      assert!(
+        !message.contains(JOURNAL_TABLE) && !message.contains(SNAPSHOT_TABLE),
+        "message must not contain table names"
+      );
+    }
+    other => panic!("expected IOError, got {:?}", other),
+  }
+}
+
+// FR6.3 / AC2.3.4 / BR3.1 / BR4.1: keep_snapshot_count = Some(n) でスナップショット付き更新を
+// 繰り返すと履歴項目が同一トランザクションで書かれ、保持フックが n 件残して剪定する
+// （delete_ttl なし → 削除方式 = FR6.5 で .unwrap() を除去した DeleteRequest 経路を通す）。
+// 現行の剪定走査（seq_nr 降順・超過分削除）では旧い側の履歴（seq_nr = 1, 2）が残る。
+// AC2.3.3 / BR2.3: 現行・履歴項目の payload は純ドメイン内容のみ（JSON 完全一致 — U3 同型）
+#[tokio::test]
+async fn test_event_store_on_dynamodb_prunes_snapshot_history() {
+  init_tracing();
+
+  let node = dynamodb_local().await;
+  let port = node.get_host_port_ipv4(4566).await.expect("Failed to get port");
+  let (client, store) = connect_store(port).await;
+  let mut store = store.with_keep_snapshot_count(Some(2)).expect("Some(2) is valid");
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  store
+    .persist_event_and_snapshot(
+      EventEnvelope::new(id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST),
+      user_account.clone(),
+      0,
+    )
+    .await
+    .expect("creation failed");
+
+  // スナップショット付き更新 × 3（履歴項目は seq_nr = 1, 2, 3, 4 の 4 件生まれ、2 件へ剪定される）
+  let mut state = user_account;
+  for (seq_nr, name) in [(2_usize, "history-1"), (3, "history-2"), (4, "history-3")] {
+    let event = state.rename(name).unwrap();
+    store
+      .persist_event_and_snapshot(
+        EventEnvelope::new(id.clone(), seq_nr, Utc::now(), event).with_manifest(RENAMED_MANIFEST),
+        state.clone(),
+        seq_nr - 1,
+      )
+      .await
+      .expect("update failed");
+  }
+
+  // 剪定後は current 1 件 + 履歴 2 件（現行走査順では旧い側 seq_nr = 1, 2 が残る）
+  let items = scan_snapshot_items(&client, &id).await;
+  let mut history_skeys: Vec<String> = items
+    .keys()
+    .filter(|skey| **skey != current_snapshot_skey(&id))
+    .cloned()
+    .collect();
+  history_skeys.sort();
+  assert_eq!(history_skeys, vec![snapshot_skey(&id, 1), snapshot_skey(&id, 2)]);
+
+  // current 項目は最新状態のまま（剪定は履歴項目のみに作用する）
+  let snapshot = store
+    .get_latest_snapshot_by_id(&id)
+    .await
+    .unwrap()
+    .expect("snapshot must exist");
+  assert_eq!(snapshot.version(), 4);
+  assert_eq!(snapshot.seq_nr(), 4);
+  assert_eq!(snapshot.aggregate().name, "history-3");
+
+  // AC2.3.3: current 項目の payload は純ドメイン内容のみ（version / seq_nr / last_updated_at の複製なし）
+  let current_payload = items
+    .get(&current_snapshot_skey(&id))
+    .expect("current payload must exist");
+  let current_json: serde_json::Value = serde_json::from_slice(current_payload).unwrap();
+  let expected_current = UserAccount {
+    id: id.clone(),
+    name: "history-3".to_string(),
+  };
+  assert_eq!(current_json, serde_json::to_value(&expected_current).unwrap());
+
+  // 履歴項目（seq_nr = 2 のスナップショット付き更新の後像）の payload も純ドメイン内容のみ
+  let history_payload = items.get(&snapshot_skey(&id, 2)).expect("history payload must exist");
+  let history_json: serde_json::Value = serde_json::from_slice(history_payload).unwrap();
+  let expected_history = UserAccount {
+    id: id.clone(),
+    name: "history-1".to_string(),
+  };
+  assert_eq!(history_json, serde_json::to_value(&expected_history).unwrap());
+}
+
+// BR3.1 / AC2.3.4: keep_snapshot_count = None（既定）は履歴項目を書かず剪定もしない
+// （剪定なし設定に書込み増幅を持ち込まない — 現行挙動との互換）
+#[tokio::test]
+async fn test_event_store_on_dynamodb_without_keep_snapshot_count_writes_no_history() {
+  init_tracing();
+
+  let node = dynamodb_local().await;
+  let port = node.get_host_port_ipv4(4566).await.expect("Failed to get port");
+  let (client, mut store) = connect_store(port).await;
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  store
+    .persist_event_and_snapshot(
+      EventEnvelope::new(id.clone(), 1, Utc::now(), created).with_manifest(CREATED_MANIFEST),
+      user_account.clone(),
+      0,
+    )
+    .await
+    .expect("creation failed");
+
+  let mut state = user_account;
+  for (seq_nr, name) in [(2_usize, "no-history-1"), (3, "no-history-2")] {
+    let event = state.rename(name).unwrap();
+    store
+      .persist_event_and_snapshot(
+        EventEnvelope::new(id.clone(), seq_nr, Utc::now(), event).with_manifest(RENAMED_MANIFEST),
+        state.clone(),
+        seq_nr - 1,
+      )
+      .await
+      .expect("update failed");
+  }
+
+  let items = scan_snapshot_items(&client, &id).await;
+  let history_skeys: Vec<&String> = items
+    .keys()
+    .filter(|skey| **skey != current_snapshot_skey(&id))
+    .collect();
+  assert!(
+    history_skeys.is_empty(),
+    "no history items must be written when keep_snapshot_count is None"
+  );
+}
+
+// U1 リファレンス意味論との対称性: 未作成（Absent）の集約への更新系呼び出しは
+// actual_version なし書式の OptimisticLockError を返す（条件式 #version=:before_version が
+// 不在項目で不成立 → TransactionCanceledException — BR1.1）
+#[tokio::test]
+async fn test_event_store_on_dynamodb_update_on_absent_aggregate_yields_optimistic_lock_error() {
+  init_tracing();
+
+  let node = dynamodb_local().await;
+  let port = node.get_host_port_ipv4(4566).await.expect("Failed to get port");
+  let (_client, mut store) = connect_store(port).await;
+
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, _created) = UserAccount::new(id.clone(), "test".to_string());
+
+  // 未作成のまま seq_nr=2 / expected_version=1 のスナップショット付き更新（W3 経路）を呼ぶ
+  let envelope = EventEnvelope::new(
+    id.clone(),
+    2,
+    Utc::now(),
+    UserAccountEvent::Renamed {
+      name: "ghost".to_string(),
+    },
+  );
+  let result = store.persist_event_and_snapshot(envelope, user_account, 1).await;
+  match result {
+    Err(EventStoreWriteError::OptimisticLockError(message)) => {
+      // actual_version を含まない書式であることを完全一致で固定する
+      assert_eq!(
+        message,
+        format!("optimistic lock failed, aid={}, expected_version=1", id)
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
 }

--- a/lib/src/event_store_for_memory.rs
+++ b/lib/src/event_store_for_memory.rs
@@ -253,13 +253,14 @@ where
   ) -> Result<(), EventStoreWriteError> {
     let aid = event.aggregate_id().to_string();
     let mut state = self.lock_state().map_err(EventStoreWriteError::OtherError)?;
-    let entry = state
-      .get_mut(&aid)
-      .ok_or_else(|| EventStoreWriteError::OtherError(format!("snapshot not found for aggregate {}", aid)))?;
-    let latest = entry
-      .snapshots
-      .last_mut()
-      .ok_or_else(|| EventStoreWriteError::OtherError(format!("snapshot not found for aggregate {}", aid)))?;
+    // BR2.3 / AC2.2.3: 対象集約が不在の更新は楽観ロック競合として扱う
+    // （状態遷移図: Absent --> Absent : W2/W3 update → OptimisticLockError。actual_version なし書式）
+    let entry = state.get_mut(&aid).ok_or_else(|| {
+      EventStoreWriteError::OptimisticLockError(format_optimistic_lock_message(&aid, expected_version, None))
+    })?;
+    let latest = entry.snapshots.last_mut().ok_or_else(|| {
+      EventStoreWriteError::OptimisticLockError(format_optimistic_lock_message(&aid, expected_version, None))
+    })?;
     // BR2.3: version CAS。競合時は統一書式の楽観ロックエラー（NFR3.2 — 許可キーのみ）
     if latest.version() != expected_version {
       return Err(EventStoreWriteError::OptimisticLockError(

--- a/lib/src/event_store_for_memory.rs
+++ b/lib/src/event_store_for_memory.rs
@@ -5,39 +5,58 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use async_trait::async_trait;
 use chrono::Duration;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tracing::instrument;
 
-use crate::event_store_backend::{SnapshotEnvelope, SnapshotMaintenance, StorageBackend};
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
+use crate::event_store_backend::{SnapshotMaintenance, StorageBackend};
 use crate::generic_event_store::GenericEventStore;
 use crate::types::{
-  format_optimistic_lock_message, Aggregate, AggregateId, Event, EventStore, EventStoreReadError, EventStoreWriteError,
+  format_optimistic_lock_message, AggregateId, EventStore, EventStoreReadError, EventStoreWriteError,
 };
 
+// FR6.1: Memory バックエンドの封筒保持への構造化。読取時の `set_version` 書き戻しは
+// 廃止し、version の正は SnapshotEnvelope（列相当）側に一本化する（FR4.3 / BR2.5）。
+// BR1.6: この impl のみ payload（A / P）へ追加で `Clone` を要求する（直列化なしで
+// 所有権付き返却するため — 文書化済みの非対称）。
+
 /// Event Store for On-Memory
-#[derive(Debug)]
-pub struct EventStoreForMemory<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
-  inner: GenericEventStore<AID, A, E, InMemoryBackend<AID, A, E>>,
+pub struct EventStoreForMemory<AID, A, P> {
+  inner: GenericEventStore<AID, A, P, InMemoryBackend<AID, A, P>>,
 }
 
-impl<AID, A, E> EventStoreForMemory<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
+// P2: derive は型パラメータ（AID / A / P）へ Debug / Clone 境界を課すため手動 impl とし、
+// payload への要求を実フィールド由来のものに限定する
+impl<AID, A, P> Debug for EventStoreForMemory<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("EventStoreForMemory").finish()
+  }
+}
+
+impl<AID, A, P> Clone for EventStoreForMemory<AID, A, P> {
+  // クローン間で同一ストアを共有する（Arcの共有クローン — Clone時の状態分岐を作らない）
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+    }
+  }
+}
+
+impl<AID, A, P> EventStoreForMemory<AID, A, P> {
   pub fn new() -> Self {
     Self {
       inner: GenericEventStore::new(InMemoryBackend::new()),
     }
   }
 
-  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Self {
-    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count);
-    self
+  /// 保持するスナップショット履歴数を設定する。
+  ///
+  /// BR4.1 / P3: 検証（`Some(0)` の拒否）は `GenericEventStore` 側の 1 箇所で行い、
+  /// このラッパーは Result を素通しする。
+  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Result<Self, EventStoreWriteError> {
+    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count)?;
+    Ok(self)
   }
 
   pub fn with_delete_ttl(mut self, delete_ttl: Option<Duration>) -> Self {
@@ -50,79 +69,70 @@ where
   }
 }
 
-impl<AID, A, E> Default for EventStoreForMemory<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
+impl<AID, A, P> Default for EventStoreForMemory<AID, A, P> {
   fn default() -> Self {
     Self::new()
   }
 }
 
-impl<AID, A, E> Clone for EventStoreForMemory<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
-  // クローン間で同一ストアを共有する（Arcの共有クローン — Clone時の状態分岐を作らない）
-  fn clone(&self) -> Self {
-    Self {
-      inner: self.inner.clone(),
-    }
-  }
-}
-
 #[async_trait]
-impl<AID, A, E> EventStore for EventStoreForMemory<AID, A, E>
+impl<AID, A, P> EventStore for EventStoreForMemory<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
 {
-  type AG = A;
+  type A = A;
   type AID = AID;
-  type EV = E;
+  type P = P;
 
-  #[instrument]
-  async fn persist_event(&mut self, event: &Self::EV, version: usize) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event(event, version).await
+  #[instrument(skip_all)]
+  async fn persist_event(
+    &mut self,
+    event: EventEnvelope<Self::AID, Self::P>,
+    expected_version: usize,
+  ) -> Result<(), EventStoreWriteError> {
+    self.inner.persist_event(event, expected_version).await
   }
 
-  #[instrument]
+  #[instrument(skip_all)]
   async fn persist_event_and_snapshot(
     &mut self,
-    event: &Self::EV,
-    aggregate: &Self::AG,
+    event: EventEnvelope<Self::AID, Self::P>,
+    aggregate: Self::A,
+    expected_version: usize,
   ) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event_and_snapshot(event, aggregate).await
+    self
+      .inner
+      .persist_event_and_snapshot(event, aggregate, expected_version)
+      .await
   }
 
-  #[instrument]
-  async fn get_latest_snapshot_by_id(&self, aid: &Self::AID) -> Result<Option<Self::AG>, EventStoreReadError> {
+  #[instrument(skip_all)]
+  async fn get_latest_snapshot_by_id(
+    &self,
+    aid: &Self::AID,
+  ) -> Result<Option<SnapshotEnvelope<Self::A>>, EventStoreReadError> {
     self.inner.get_latest_snapshot_by_id(aid).await
   }
 
-  #[instrument]
+  #[instrument(skip_all)]
   async fn get_events_by_id_since_seq_nr(
     &self,
     aid: &Self::AID,
     seq_nr: usize,
-  ) -> Result<Vec<Self::EV>, EventStoreReadError> {
+  ) -> Result<Vec<EventEnvelope<Self::AID, Self::P>>, EventStoreReadError> {
     self.inner.get_events_by_id_since_seq_nr(aid, seq_nr).await
   }
 }
 
 /// Memoryバックエンドの内部状態（キー=集約ID文字列。公開APIへ露出しない）
-#[derive(Debug)]
-struct InMemoryStoreState<A, E> {
-  events: Vec<E>,
+struct InMemoryStoreState<AID, A, P> {
+  events: Vec<EventEnvelope<AID, P>>,
   snapshots: Vec<SnapshotEnvelope<A>>,
 }
 
-impl<A, E> InMemoryStoreState<A, E> {
+impl<AID, A, P> InMemoryStoreState<AID, A, P> {
   fn new() -> Self {
     Self {
       events: Vec::new(),
@@ -131,27 +141,24 @@ impl<A, E> InMemoryStoreState<A, E> {
   }
 }
 
-type StoreStateMap<A, E> = HashMap<String, InMemoryStoreState<A, E>>;
+type StoreStateMap<AID, A, P> = HashMap<String, InMemoryStoreState<AID, A, P>>;
 
 // fnポインタ経由の型マーカー — Send/Sync自動導出を阻害しない
-type TypeMarker<AID, A, E> = fn() -> (AID, A, E);
+type TypeMarker<AID, A, P> = fn() -> (AID, A, P);
 
-#[derive(Debug)]
-struct InMemoryBackend<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
-  state: Arc<Mutex<StoreStateMap<A, E>>>,
-  _marker: PhantomData<TypeMarker<AID, A, E>>,
+struct InMemoryBackend<AID, A, P> {
+  state: Arc<Mutex<StoreStateMap<AID, A, P>>>,
+  _marker: PhantomData<TypeMarker<AID, A, P>>,
 }
 
-impl<AID, A, E> InMemoryBackend<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
+// P2: derive は AID / A / P へ Debug 境界を課すため手動 impl とする（内部状態は表示しない）
+impl<AID, A, P> Debug for InMemoryBackend<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("InMemoryBackend").finish()
+  }
+}
+
+impl<AID, A, P> InMemoryBackend<AID, A, P> {
   fn new() -> Self {
     Self {
       state: Arc::new(Mutex::new(HashMap::new())),
@@ -160,8 +167,8 @@ where
   }
 
   // ロックは各メソッド内で取得・解放し、ガード保持中に `.await` しない。
-  // ポイズニングはpanicさせず文字列化してエラーへ写像する（ガード起因の機密混入なし）。
-  fn lock_state(&self) -> Result<MutexGuard<'_, StoreStateMap<A, E>>, String> {
+  // ポイズニングはpanicさせず文字列化してエラーへ写像する（BR5.1 — ガード起因の機密混入なし）。
+  fn lock_state(&self) -> Result<MutexGuard<'_, StoreStateMap<AID, A, P>>, String> {
     self
       .state
       .lock()
@@ -169,13 +176,8 @@ where
   }
 }
 
-impl<AID, A, E> Clone for InMemoryBackend<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
-  // Arcの共有クローン — deriveはAID/A/EへのClone境界を要求するため手動実装とする
+impl<AID, A, P> Clone for InMemoryBackend<AID, A, P> {
+  // Arcの共有クローン — deriveはAID/A/PへのClone境界を要求するため手動実装とする
   fn clone(&self) -> Self {
     Self {
       state: Arc::clone(&self.state),
@@ -185,14 +187,15 @@ where
 }
 
 #[async_trait]
-impl<AID, A, E> StorageBackend<AID, A, E> for InMemoryBackend<AID, A, E>
+impl<AID, A, P> StorageBackend<AID, A, P> for InMemoryBackend<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Clone + Send + Sync + 'static,
+  P: Clone + Send + Sync + 'static,
 {
   async fn fetch_latest_snapshot(&self, aid: &AID) -> Result<Option<SnapshotEnvelope<A>>, EventStoreReadError> {
     let state = self.lock_state().map_err(EventStoreReadError::OtherError)?;
+    // BR2.5: version / seq_nr は保存済み封筒（列相当）の値をそのまま返す — payload からの補正はない
     Ok(
       state
         .get(&aid.to_string())
@@ -200,8 +203,13 @@ where
     )
   }
 
-  async fn fetch_events_since(&self, aid: &AID, seq_nr: usize) -> Result<Vec<E>, EventStoreReadError> {
+  async fn fetch_events_since(
+    &self,
+    aid: &AID,
+    seq_nr: usize,
+  ) -> Result<Vec<EventEnvelope<AID, P>>, EventStoreReadError> {
     let state = self.lock_state().map_err(EventStoreReadError::OtherError)?;
+    // BR3.2: 保存時の封筒（メタデータ込み）を seq_nr 昇順（挿入順）でそのまま返す
     Ok(match state.get(&aid.to_string()) {
       Some(entry) => entry
         .events
@@ -215,7 +223,7 @@ where
 
   async fn create_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: &A,
     _maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError> {
@@ -223,22 +231,22 @@ where
     let mut state = self.lock_state().map_err(EventStoreWriteError::OtherError)?;
     let entry = state.entry(aid.clone()).or_insert_with(InMemoryStoreState::new);
     if let Some(latest) = entry.snapshots.last() {
+      // 既存集約への新規作成は競合（W1）。新規作成の expected_version は 0（BR2.6 で保証済み）
       return Err(EventStoreWriteError::OptimisticLockError(
-        format_optimistic_lock_message(&aid, aggregate.version(), Some(latest.version)),
+        format_optimistic_lock_message(&aid, 0, Some(latest.version())),
       ));
     }
-    entry.snapshots.push(SnapshotEnvelope {
-      aggregate: aggregate.clone(),
-      seq_nr: aggregate.seq_nr(),
-      version: aggregate.version(),
-    });
+    // W1: snapshot は version = 1、seq_nr = event.seq_nr() で作成する
+    entry
+      .snapshots
+      .push(SnapshotEnvelope::new(aggregate.clone(), event.seq_nr(), 1));
     entry.events.push(event.clone());
     Ok(())
   }
 
   async fn update_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: Option<&A>,
     expected_version: usize,
     _maintenance: &SnapshotMaintenance,
@@ -252,21 +260,21 @@ where
       .snapshots
       .last_mut()
       .ok_or_else(|| EventStoreWriteError::OtherError(format!("snapshot not found for aggregate {}", aid)))?;
-    if latest.version != expected_version {
+    // BR2.3: version CAS。競合時は統一書式の楽観ロックエラー（NFR3.2 — 許可キーのみ）
+    if latest.version() != expected_version {
       return Err(EventStoreWriteError::OptimisticLockError(
-        format_optimistic_lock_message(&aid, expected_version, Some(latest.version)),
+        format_optimistic_lock_message(&aid, expected_version, Some(latest.version())),
       ));
     }
+    // FR4.3 / BR2.5: version 加算は列（封筒）側で行う。`set_version` 相当の
+    // payload への書き戻しは存在しない
     let new_version = expected_version + 1;
-    latest.version = new_version;
-    if let Some(aggregate) = aggregate {
-      let mut stored = aggregate.clone();
-      stored.set_version(new_version);
-      latest.seq_nr = aggregate.seq_nr();
-      latest.aggregate = stored;
-    } else {
-      latest.aggregate.set_version(new_version);
-    }
+    *latest = match aggregate {
+      // W3: スナップショット付き更新 — aggregate / seq_nr / version を新値へ置換
+      Some(aggregate) => SnapshotEnvelope::new(aggregate.clone(), event.seq_nr(), new_version),
+      // W2: イベントのみ更新 — aggregate / seq_nr は据え置き、version のみ加算
+      None => SnapshotEnvelope::new(latest.aggregate().clone(), latest.seq_nr(), new_version),
+    };
     entry.events.push(event.clone());
     Ok(())
   }

--- a/lib/src/event_store_for_memory_test.rs
+++ b/lib/src/event_store_for_memory_test.rs
@@ -273,3 +273,34 @@ async fn test_event_store_on_memory_persists_plain_clone_type_end_to_end() {
   assert_eq!(events[0].manifest(), "");
   assert_eq!(events[0].payload().name, "renamed-again");
 }
+
+// BR2.3 / AC2.2.3: 未作成（Absent）の集約への更新系呼び出しは OptimisticLockError を返す
+// （状態遷移図: Absent --> Absent : W2/W3 update → OptimisticLockError。actual_version なし書式）
+#[tokio::test]
+async fn test_event_store_on_memory_update_on_absent_aggregate_yields_optimistic_lock_error() {
+  let mut store = new_memory_event_store();
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, _created) = UserAccount::new(id.clone(), "test".to_string());
+
+  // 未作成のまま seq_nr=2 / expected_version=1 のスナップショット付き更新（W3 経路）を呼ぶ
+  let envelope = EventEnvelope::new(
+    id.clone(),
+    2,
+    Utc::now(),
+    UserAccountEvent::Renamed {
+      name: "ghost".to_string(),
+    },
+  );
+  let result = store.persist_event_and_snapshot(envelope, user_account, 1).await;
+  match result {
+    Err(EventStoreWriteError::OptimisticLockError(message)) => {
+      // actual_version を含まない書式であることを完全一致で固定する
+      assert_eq!(
+        message,
+        format!("optimistic lock failed, aid={}, expected_version=1", id)
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
+}

--- a/lib/src/event_store_for_memory_test.rs
+++ b/lib/src/event_store_for_memory_test.rs
@@ -1,15 +1,28 @@
+use chrono::{TimeZone, Utc};
 use event_store_adapter_test_utils_rs::id_generator::id_generate;
+use serde::{Deserialize, Serialize};
 
+use crate::event_envelope::EventEnvelope;
 use crate::event_store_for_memory::EventStoreForMemory;
 use crate::event_store_test_support::{
-  exercise_user_account_flow, find_by_id, init_tracing, UserAccount, UserAccountEvent, UserAccountId,
+  assert_optimistic_lock_message_format, exercise_user_account_flow, find_by_id, init_tracing, UserAccount,
+  UserAccountEvent, UserAccountId, RENAMED_MANIFEST,
 };
-use crate::types::{Aggregate, EventStore, EventStoreWriteError};
+use crate::types::{EventStore, EventStoreWriteError};
 
 fn new_memory_event_store() -> EventStoreForMemory<UserAccountId, UserAccount, UserAccountEvent> {
   EventStoreForMemory::new()
 }
 
+fn renamed_envelope(
+  id: &UserAccountId,
+  seq_nr: usize,
+  payload: UserAccountEvent,
+) -> EventEnvelope<UserAccountId, UserAccountEvent> {
+  EventEnvelope::new(id.clone(), seq_nr, Utc::now(), payload).with_manifest(RENAMED_MANIFEST)
+}
+
+// FR7.1 / AC2.1系: 共有シナリオ（8 手順・封筒メタデータ往復 assert 含む）が Memory で green
 #[tokio::test]
 async fn test_event_store_on_memory() {
   init_tracing();
@@ -22,17 +35,31 @@ async fn test_event_store_on_memory() {
     .expect("scenario failed");
 }
 
+// BR2.2: イベントのみ API への seq_nr == 1（新規作成）は ContractViolation（panic しない — BR5.1）
 #[tokio::test]
 async fn test_event_store_on_memory_persist_event_rejects_creation_event() {
   let mut event_store = new_memory_event_store();
   let id = UserAccountId::new(id_generate().to_string());
-  let (user_account, created) = UserAccount::new(id, "test".to_string());
+  let (_user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  let envelope = EventEnvelope::new(id, 1, Utc::now(), created);
 
-  // AC3.1.1: 作成イベントの persist_event 渡しは panic せず Err を返す
-  let result = event_store.persist_event(&created, user_account.version()).await;
-  assert!(matches!(result, Err(EventStoreWriteError::OtherError(_))));
+  let result = event_store.persist_event(envelope, 0).await;
+  assert!(matches!(result, Err(EventStoreWriteError::ContractViolation(_))));
 }
 
+// BR4.1: keep_snapshot_count = Some(0) はビルダーで拒否される（ラッパーの Result 素通し — P3）
+#[tokio::test]
+async fn test_event_store_on_memory_with_keep_snapshot_count_zero_is_rejected() {
+  let result = new_memory_event_store().with_keep_snapshot_count(Some(0));
+  assert!(matches!(result, Err(EventStoreWriteError::ContractViolation(_))));
+
+  let store = new_memory_event_store()
+    .with_keep_snapshot_count(Some(1))
+    .expect("Some(1) is valid");
+  assert_eq!(store.maintenance().keep_snapshot_count, Some(1));
+}
+
+// NFR3.2 / AC2.2系: 楽観ロックエラーの統一書式契約（許可キーのみ）を固定する回帰テスト
 #[tokio::test]
 async fn test_event_store_on_memory_optimistic_lock_error_contract() {
   let mut store_a = new_memory_event_store();
@@ -40,19 +67,24 @@ async fn test_event_store_on_memory_optimistic_lock_error_contract() {
   let id = UserAccountId::new(id_generate().to_string());
   let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
   store_a
-    .persist_event_and_snapshot(&created, &user_account)
+    .persist_event_and_snapshot(EventEnvelope::new(id.clone(), 1, Utc::now(), created), user_account, 0)
     .await
     .unwrap();
 
-  let mut account_a = find_by_id(&mut store_a, &id).await.unwrap().unwrap();
-  let mut account_b = find_by_id(&mut store_b, &id).await.unwrap().unwrap();
+  let mut account_a = find_by_id(&store_a, &id).await.unwrap().unwrap();
+  let mut account_b = find_by_id(&store_b, &id).await.unwrap().unwrap();
 
-  let event_a = account_a.rename("first").unwrap();
-  store_a.persist_event(&event_a, account_a.version()).await.unwrap();
+  let event_a = account_a.state.rename("first").unwrap();
+  store_a
+    .persist_event(renamed_envelope(&id, account_a.seq_nr + 1, event_a), account_a.version)
+    .await
+    .unwrap();
 
-  // 同一バージョン(1)への後発の書込みは BR1.2 書式の OptimisticLockError で失敗する
-  let event_b = account_b.rename("second").unwrap();
-  let result = store_b.persist_event(&event_b, account_b.version()).await;
+  // 同一バージョン(1)への後発の書込みは統一書式の OptimisticLockError で失敗する
+  let event_b = account_b.state.rename("second").unwrap();
+  let result = store_b
+    .persist_event(renamed_envelope(&id, account_b.seq_nr + 1, event_b), account_b.version)
+    .await;
   match result {
     Err(EventStoreWriteError::OptimisticLockError(message)) => {
       assert_eq!(
@@ -62,11 +94,13 @@ async fn test_event_store_on_memory_optimistic_lock_error_contract() {
           id
         )
       );
+      assert_optimistic_lock_message_format(&message);
     }
     other => panic!("expected OptimisticLockError, got {:?}", other),
   }
 }
 
+// NFR4.1 / AC2.2.1: 同時更新の競合パス — 一方のみ成功し他方が OptimisticLockError になる
 #[tokio::test]
 async fn test_event_store_on_memory_concurrent_conflict_yields_optimistic_lock_error() {
   let store = new_memory_event_store();
@@ -75,23 +109,23 @@ async fn test_event_store_on_memory_concurrent_conflict_yields_optimistic_lock_e
   {
     let mut writer = store.clone();
     writer
-      .persist_event_and_snapshot(&created, &user_account)
+      .persist_event_and_snapshot(EventEnvelope::new(id.clone(), 1, Utc::now(), created), user_account, 0)
       .await
       .unwrap();
   }
 
   let mut store_a = store.clone();
   let mut store_b = store.clone();
-  let mut account_a = find_by_id(&mut store_a, &id).await.unwrap().unwrap();
-  let mut account_b = find_by_id(&mut store_b, &id).await.unwrap().unwrap();
-  let event_a = account_a.rename("conflict-a").unwrap();
-  let event_b = account_b.rename("conflict-b").unwrap();
-  let version_a = account_a.version();
-  let version_b = account_b.version();
+  let mut account_a = find_by_id(&store_a, &id).await.unwrap().unwrap();
+  let mut account_b = find_by_id(&store_b, &id).await.unwrap().unwrap();
+  let envelope_a = renamed_envelope(&id, account_a.seq_nr + 1, account_a.state.rename("conflict-a").unwrap());
+  let envelope_b = renamed_envelope(&id, account_b.seq_nr + 1, account_b.state.rename("conflict-b").unwrap());
+  let version_a = account_a.version;
+  let version_b = account_b.version;
 
   let (result_a, result_b) = tokio::join!(
-    async move { store_a.persist_event(&event_a, version_a).await },
-    async move { store_b.persist_event(&event_b, version_b).await },
+    async move { store_a.persist_event(envelope_a, version_a).await },
+    async move { store_b.persist_event(envelope_b, version_b).await },
   );
 
   let err = match (result_a, result_b) {
@@ -109,11 +143,13 @@ async fn test_event_store_on_memory_concurrent_conflict_yields_optimistic_lock_e
         "unexpected message: {}",
         message
       );
+      assert_optimistic_lock_message_format(&message);
     }
     other => panic!("expected OptimisticLockError, got {:?}", other),
   }
 }
 
+// クローン共有契約: クローン間で同一ストアを共有する（Clone時の状態分岐を作らない）
 #[tokio::test]
 async fn test_event_store_on_memory_clone_shares_state() {
   let mut original = new_memory_event_store();
@@ -121,22 +157,119 @@ async fn test_event_store_on_memory_clone_shares_state() {
   let id = UserAccountId::new(id_generate().to_string());
   let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
   original
-    .persist_event_and_snapshot(&created, &user_account)
+    .persist_event_and_snapshot(EventEnvelope::new(id.clone(), 1, Utc::now(), created), user_account, 0)
     .await
     .unwrap();
 
   // クローン側から元の書込みが見える
-  let mut from_clone = find_by_id(&mut cloned, &id)
+  let mut from_clone = find_by_id(&cloned, &id)
     .await
     .unwrap()
     .expect("clone must see the original's write");
-  assert_eq!(from_clone.version(), 1);
+  assert_eq!(from_clone.version, 1);
 
   // クローン側の書込みが元から見える（Clone間の状態分岐が存在しない）
-  let event = from_clone.rename("renamed-via-clone").unwrap();
-  cloned.persist_event(&event, from_clone.version()).await.unwrap();
+  let event = from_clone.state.rename("renamed-via-clone").unwrap();
+  cloned
+    .persist_event(renamed_envelope(&id, from_clone.seq_nr + 1, event), from_clone.version)
+    .await
+    .unwrap();
 
-  let from_original = find_by_id(&mut original, &id).await.unwrap().unwrap();
-  assert_eq!(from_original.version(), 2);
-  assert_eq!(from_original.seq_nr(), 2);
+  let from_original = find_by_id(&original, &id).await.unwrap().unwrap();
+  assert_eq!(from_original.version, 2);
+  assert_eq!(from_original.seq_nr, 2);
+  assert_eq!(from_original.state.name, "renamed-via-clone");
+}
+
+// FR7.3 ③ / NFR2 / US2.2: Memory 経由の永続化検証 — derive(Serialize, Deserialize, Clone) のみの
+// プレーン型（Debug なし — BR1.6 の Memory 非対称は +Clone のみ）で W1〜W4 を一気通貫する
+#[tokio::test]
+async fn test_event_store_on_memory_persists_plain_clone_type_end_to_end() {
+  #[derive(Serialize, Deserialize, Clone)]
+  struct PlainAggregate {
+    name: String,
+  }
+
+  #[derive(Serialize, Deserialize, Clone)]
+  struct PlainPayload {
+    name: String,
+  }
+
+  let mut store: EventStoreForMemory<UserAccountId, PlainAggregate, PlainPayload> = EventStoreForMemory::new();
+  let id = UserAccountId::new(id_generate().to_string());
+  let occurred_at = Utc.with_ymd_and_hms(2026, 8, 27, 0, 0, 0).unwrap();
+
+  // W1: 新規作成（seq_nr=1, expected_version=0）
+  store
+    .persist_event_and_snapshot(
+      EventEnvelope::new(
+        id.clone(),
+        1,
+        occurred_at,
+        PlainPayload {
+          name: "created".to_string(),
+        },
+      )
+      .with_manifest("plain/v1"),
+      PlainAggregate {
+        name: "one".to_string(),
+      },
+      0,
+    )
+    .await
+    .unwrap();
+
+  // W3: 更新（スナップショット付き、seq_nr=2, expected_version=1）
+  store
+    .persist_event_and_snapshot(
+      EventEnvelope::new(
+        id.clone(),
+        2,
+        occurred_at,
+        PlainPayload {
+          name: "renamed".to_string(),
+        },
+      ),
+      PlainAggregate {
+        name: "two".to_string(),
+      },
+      1,
+    )
+    .await
+    .unwrap();
+
+  // W2: イベントのみ更新（seq_nr=3, expected_version=2）
+  store
+    .persist_event(
+      EventEnvelope::new(
+        id.clone(),
+        3,
+        occurred_at,
+        PlainPayload {
+          name: "renamed-again".to_string(),
+        },
+      ),
+      2,
+    )
+    .await
+    .unwrap();
+
+  // W4: 復元 — スナップショット封筒 + 差分イベント封筒の読取
+  let snapshot = store
+    .get_latest_snapshot_by_id(&id)
+    .await
+    .unwrap()
+    .expect("snapshot must exist");
+  assert_eq!(snapshot.version(), 3);
+  assert_eq!(snapshot.seq_nr(), 2);
+  assert_eq!(snapshot.aggregate().name, "two");
+
+  let events = store
+    .get_events_by_id_since_seq_nr(&id, snapshot.seq_nr() + 1)
+    .await
+    .unwrap();
+  assert_eq!(events.len(), 1);
+  assert_eq!(events[0].seq_nr(), 3);
+  assert_eq!(events[0].manifest(), "");
+  assert_eq!(events[0].payload().name, "renamed-again");
 }

--- a/lib/src/event_store_for_sqlite.rs
+++ b/lib/src/event_store_for_sqlite.rs
@@ -1,25 +1,38 @@
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use async_trait::async_trait;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use rusqlite::{params, Connection, ErrorCode, OptionalExtension, ToSql, Transaction};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
-use crate::event_store_backend::{SnapshotEnvelope, SnapshotMaintenance, StorageBackend};
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
+use crate::event_store_backend::{SnapshotMaintenance, StorageBackend};
 use crate::generic_event_store::GenericEventStore;
 use crate::key_resolver::{DefaultKeyResolver, KeyResolver};
 use crate::serializer::{EventSerializer, JsonEventSerializer, JsonSnapshotSerializer, SnapshotSerializer};
 use crate::types::{
-  format_optimistic_lock_message, Aggregate, AggregateId, Event, EventStore, EventStoreReadError, EventStoreWriteError,
+  format_optimistic_lock_message, AggregateId, EventStore, EventStoreReadError, EventStoreWriteError,
 };
+
+// FR6.1: SQLite バックエンドの v3 封筒化。封筒⇔列の 1:1 マッピング（AC2.1.1）、単一トランザクション
+// 内の条件付き UPDATE による原子的 CAS の現行維持（BR1.1 / P10 / NFR4.4）、skey 判別へ一本化した
+// 保持ポリシー（BR2.4 / BR3.1）を StorageBackend + GenericEventStore の 2 層委譲構造の上に実装する。
 
 /// 既存バックエンドの利用実績と同じ既定シャード数（pkey書き込み分散幅）
 const DEFAULT_SHARD_COUNT: u64 = 64;
 
-/// スキーマは接続確立時に不存在なら作成する（冪等 — BR2.1。利用者DDLなし）。
-/// 書き込みアドレスはPK (pkey, skey)、読み込みは (aid, seq_nr) 索引（BR2.2）。
+// BR2.4: 現行スロット行の skey は seq_nr=0 マーカーで解決する（キー設計の現行維持）。
+// このマーカーは物理キーの解決だけに使い、seq_nr 列の実値（event.seq_nr()）とは混用しない。
+const CURRENT_SNAPSHOT_SKEY_MARKER: usize = 0;
+
+/// スキーマは接続確立時に不存在なら作成する（冪等 — 利用者DDLなし）。
+/// 書き込みアドレスはPK (pkey, skey)、読み込みは (aid, seq_nr) 索引。
+/// BR2.1: journal は封筒メタデータ 4 点 + payload の列を持ち、manifest 列
+/// （TEXT NOT NULL DEFAULT ''）を v3 で新設する（v2 で作成済み DB との読取互換は保証しない — 既決）。
+/// occurred_at 列は epoch nanos の INTEGER（供給値の完全往復 — 下記 occurred_at_nanos 参照）。
 const CREATE_SCHEMA_SQL: &str = "\
 CREATE TABLE IF NOT EXISTS journal (
   pkey TEXT NOT NULL,
@@ -28,6 +41,7 @@ CREATE TABLE IF NOT EXISTS journal (
   seq_nr INTEGER NOT NULL,
   payload BLOB NOT NULL,
   occurred_at INTEGER NOT NULL,
+  manifest TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (pkey, skey)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS journal_aid_seq_nr_idx ON journal (aid, seq_nr);
@@ -47,29 +61,47 @@ CREATE INDEX IF NOT EXISTS snapshot_aid_seq_nr_idx ON snapshot (aid, seq_nr);
 const INSERT_SNAPSHOT_SQL: &str =
   "INSERT INTO snapshot (pkey, skey, aid, seq_nr, version, payload, last_updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
 
+// BR2.1 / AC2.1.1 / AC5.1.1: 1 封筒 = journal 1 行。メタデータ 4 点（aid / seq_nr / occurred_at /
+// manifest）+ payload を列へ 1:1 で書く（manifest 省略時は空文字列がそのまま格納される — U1 BR1.2）
 const INSERT_JOURNAL_SQL: &str =
-  "INSERT INTO journal (pkey, skey, aid, seq_nr, payload, occurred_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)";
+  "INSERT INTO journal (pkey, skey, aid, seq_nr, payload, occurred_at, manifest) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
 
 /// Event Store for SQLite.
 ///
 /// Persists events and snapshots to a local SQLite database (a file or `:memory:`) and
 /// creates the required tables and indexes on construction. The supported sharing unit is
 /// one store instance and its clones (which share the underlying connection); opening the
-/// same database file from multiple store instances or processes is out of scope.
-#[derive(Debug)]
-pub struct EventStoreForSqlite<AID, A, E>
+/// same database file from multiple store instances or processes is out of scope (NFR3.9 —
+/// unsupported concurrent access surfaces as an immediate `IOError`, not silent corruption).
+pub struct EventStoreForSqlite<AID, A, P>
 where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
-  inner: GenericEventStore<AID, A, E, SqliteBackend<AID, A, E>>,
+  AID: AggregateId, {
+  inner: GenericEventStore<AID, A, P, SqliteBackend<AID, A, P>>,
 }
 
-impl<AID, A, E> EventStoreForSqlite<AID, A, E>
+// P2(U1): derive は型パラメータ（A / P）へ Debug / Clone 境界を課すため手動 impl とし、
+// payload への要求を実フィールド由来のものに限定する（BR1.6 の最小境界維持）
+impl<AID: AggregateId, A, P> Debug for EventStoreForSqlite<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("EventStoreForSqlite").finish()
+  }
+}
+
+impl<AID: AggregateId, A, P> Clone for EventStoreForSqlite<AID, A, P> {
+  // クローン間で基底接続を共有する（`:memory:` のインスタンス単位共有と
+  // 決定的競合テストの前提。Clone時の状態分岐を作らない — NFR3.9 の共有単位）
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+    }
+  }
+}
+
+impl<AID, A, P> EventStoreForSqlite<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   /// Creates an event store backed by the SQLite database file at `path`.
   ///
@@ -97,17 +129,19 @@ where
     })
   }
 
-  /// Sets the number of historical snapshots to keep and returns the updated store.
-  /// `Some(0)` keeps no history rows: existing ones are pruned and new ones are not inserted.
-  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Self {
-    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count);
-    self
+  /// 保持するスナップショット履歴数を設定する。
+  ///
+  /// BR4.1(U1) / P3: 検証（`Some(0)` の拒否）は `GenericEventStore` 側の 1 箇所で行い、
+  /// このラッパーは Result を素通しする。
+  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Result<Self, EventStoreWriteError> {
+    self.inner = self.inner.with_keep_snapshot_count(keep_snapshot_count)?;
+    Ok(self)
   }
 
-  /// Sets the retention period for historical snapshots and returns the updated store.
-  /// Takes effect only when `with_keep_snapshot_count` is also configured (contract-symmetric
-  /// with the DynamoDB backend); without a count, no history rows are recorded and this
-  /// setting has no effect.
+  /// 履歴スナップショットの保持期限を設定する。
+  ///
+  /// `with_keep_snapshot_count` と併用時のみ効果を持つ（`SnapshotMaintenance` の現行契約）。
+  /// 保持数の設定なしでは履歴行が記録されないため、この設定は作用対象を持たない。
   pub fn with_delete_ttl(mut self, delete_ttl: Option<Duration>) -> Self {
     self.inner = self.inner.with_delete_ttl(delete_ttl);
     self
@@ -127,7 +161,7 @@ where
   }
 
   /// Sets the event serializer and returns the updated store.
-  pub fn with_event_serializer(mut self, serializer: Arc<dyn EventSerializer<E>>) -> Self {
+  pub fn with_event_serializer(mut self, serializer: Arc<dyn EventSerializer<P>>) -> Self {
     self.inner.backend_mut().set_event_serializer(serializer);
     self
   }
@@ -144,45 +178,41 @@ where
   }
 }
 
-impl<AID, A, E> Clone for EventStoreForSqlite<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
-  // クローン間で基底接続を共有する（BR2.5 — `:memory:` のインスタンス単位共有と
-  // 決定的競合テストの前提。Clone時の状態分岐を作らない）
-  fn clone(&self) -> Self {
-    Self {
-      inner: self.inner.clone(),
-    }
-  }
-}
-
 #[async_trait]
-impl<AID, A, E> EventStore for EventStoreForSqlite<AID, A, E>
+impl<AID, A, P> EventStore for EventStoreForSqlite<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
-  type AG = A;
+  type A = A;
   type AID = AID;
-  type EV = E;
+  type P = P;
 
-  async fn persist_event(&mut self, event: &Self::EV, version: usize) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event(event, version).await
+  async fn persist_event(
+    &mut self,
+    event: EventEnvelope<Self::AID, Self::P>,
+    expected_version: usize,
+  ) -> Result<(), EventStoreWriteError> {
+    self.inner.persist_event(event, expected_version).await
   }
 
   async fn persist_event_and_snapshot(
     &mut self,
-    event: &Self::EV,
-    aggregate: &Self::AG,
+    event: EventEnvelope<Self::AID, Self::P>,
+    aggregate: Self::A,
+    expected_version: usize,
   ) -> Result<(), EventStoreWriteError> {
-    self.inner.persist_event_and_snapshot(event, aggregate).await
+    self
+      .inner
+      .persist_event_and_snapshot(event, aggregate, expected_version)
+      .await
   }
 
-  async fn get_latest_snapshot_by_id(&self, aid: &Self::AID) -> Result<Option<Self::AG>, EventStoreReadError> {
+  async fn get_latest_snapshot_by_id(
+    &self,
+    aid: &Self::AID,
+  ) -> Result<Option<SnapshotEnvelope<Self::A>>, EventStoreReadError> {
     self.inner.get_latest_snapshot_by_id(aid).await
   }
 
@@ -190,35 +220,48 @@ where
     &self,
     aid: &Self::AID,
     seq_nr: usize,
-  ) -> Result<Vec<Self::EV>, EventStoreReadError> {
+  ) -> Result<Vec<EventEnvelope<Self::AID, Self::P>>, EventStoreReadError> {
     self.inner.get_events_by_id_since_seq_nr(aid, seq_nr).await
   }
 }
 
-// fnポインタ経由の型マーカー — Send/Sync自動導出を阻害しない
-type TypeMarker<AID, A, E> = fn() -> (AID, A, E);
-
 /// SQLiteバックエンドの内部状態。基底接続は排他制御付きで共有し、
-/// ロック型・ガード・Arcは公開シグネチャへ露出しない（隠蔽境界 — BR2.6）
-#[derive(Debug)]
-struct SqliteBackend<AID, A, E>
+/// ロック型・ガード・Arcは公開シグネチャへ露出しない（隠蔽境界）
+struct SqliteBackend<AID, A, P>
 where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>, {
+  AID: AggregateId, {
   connection: Arc<Mutex<Connection>>,
   shard_count: u64,
   key_resolver: Arc<dyn KeyResolver<ID = AID>>,
-  event_serializer: Arc<dyn EventSerializer<E>>,
+  event_serializer: Arc<dyn EventSerializer<P>>,
   snapshot_serializer: Arc<dyn SnapshotSerializer<A>>,
-  _marker: PhantomData<TypeMarker<AID, A, E>>,
 }
 
-impl<AID, A, E> SqliteBackend<AID, A, E>
+// P2(U1): derive は A / P へ Debug 境界を課すため手動 impl とする（内部構成は表示しない）
+impl<AID: AggregateId, A, P> Debug for SqliteBackend<AID, A, P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("SqliteBackend").finish()
+  }
+}
+
+impl<AID: AggregateId, A, P> Clone for SqliteBackend<AID, A, P> {
+  // Arcの共有クローン — 基底接続を共有する（NFR3.9 の共有単位）
+  fn clone(&self) -> Self {
+    Self {
+      connection: Arc::clone(&self.connection),
+      shard_count: self.shard_count,
+      key_resolver: Arc::clone(&self.key_resolver),
+      event_serializer: Arc::clone(&self.event_serializer),
+      snapshot_serializer: Arc::clone(&self.snapshot_serializer),
+    }
+  }
+}
+
+impl<AID, A, P> SqliteBackend<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   fn new(connection: Connection) -> Self {
     Self {
@@ -227,7 +270,6 @@ where
       key_resolver: Arc::new(DefaultKeyResolver::default()),
       event_serializer: Arc::new(JsonEventSerializer::default()),
       snapshot_serializer: Arc::new(JsonSnapshotSerializer::default()),
-      _marker: PhantomData,
     }
   }
 
@@ -239,7 +281,7 @@ where
     self.key_resolver = key_resolver;
   }
 
-  fn set_event_serializer(&mut self, serializer: Arc<dyn EventSerializer<E>>) {
+  fn set_event_serializer(&mut self, serializer: Arc<dyn EventSerializer<P>>) {
     self.event_serializer = serializer;
   }
 
@@ -252,7 +294,7 @@ where
   }
 
   // shard_count=0 はキー解決（hash % shard_count）がゼロ除算でpanicするため、
-  // キー解決前に中立エラーで拒否する（panic禁止のエラー契約を維持）
+  // キー解決前に中立エラーで拒否する（panic禁止のエラー契約を維持 — BR4.1）
   fn ensure_shard_count(&self) -> Result<(), EventStoreWriteError> {
     if self.shard_count == 0 {
       return Err(EventStoreWriteError::OtherError(
@@ -266,7 +308,11 @@ where
     self.key_resolver.resolve_sort_key(id, seq_nr)
   }
 
-  // ロックは各メソッド内で取得・解放し、ガード保持中に `.await` しない（BR2.6）。
+  fn current_slot_skey(&self, id: &AID) -> String {
+    self.resolve_skey(id, CURRENT_SNAPSHOT_SKEY_MARKER)
+  }
+
+  // ロックは各メソッド内で取得・解放し、ガード保持中に `.await` しない。
   // ポイズニングはpanicさせず文字列化してエラーへ写像する（ガード起因の機密混入なし）。
   fn lock_connection(&self) -> Result<MutexGuard<'_, Connection>, String> {
     self
@@ -276,40 +322,24 @@ where
   }
 }
 
-impl<AID, A, E> Clone for SqliteBackend<AID, A, E>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-{
-  // Arcの共有クローン — 基底接続を共有する（BR2.5）
-  fn clone(&self) -> Self {
-    Self {
-      connection: Arc::clone(&self.connection),
-      shard_count: self.shard_count,
-      key_resolver: Arc::clone(&self.key_resolver),
-      event_serializer: Arc::clone(&self.event_serializer),
-      snapshot_serializer: Arc::clone(&self.snapshot_serializer),
-      _marker: PhantomData,
-    }
-  }
-}
-
 #[async_trait]
-impl<AID, A, E> StorageBackend<AID, A, E> for SqliteBackend<AID, A, E>
+impl<AID, A, P> StorageBackend<AID, A, P> for SqliteBackend<AID, A, P>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
   async fn fetch_latest_snapshot(&self, aid: &AID) -> Result<Option<SnapshotEnvelope<A>>, EventStoreReadError> {
-    // 現行スロット行（seq_nr=0）を読み込み索引 (aid, seq_nr) で取得する（BR2.2）
+    // BR2.4: 現行スロット行は skey（主キー照合 — マーカー 0）で特定する
+    // （seq_nr 列の実値化により、旧実装の「WHERE seq_nr = 0」列値判別は成立しない）
+    let pkey = self.resolve_pkey(aid);
+    let skey = self.current_slot_skey(aid);
     let row = {
       let connection = self.lock_connection().map_err(EventStoreReadError::OtherError)?;
       connection
         .query_row(
-          "SELECT payload, version, seq_nr FROM snapshot WHERE aid = ?1 AND seq_nr = 0 LIMIT 1",
-          params![aid.to_string()],
+          "SELECT payload, version, seq_nr FROM snapshot WHERE pkey = ?1 AND skey = ?2",
+          params![pkey, skey],
           |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?, row.get::<_, i64>(2)?)),
         )
         .optional()
@@ -318,39 +348,55 @@ where
     match row {
       None => Ok(None),
       Some((payload, version, seq_nr)) => {
-        let version = version as usize;
-        let mut aggregate = *self.snapshot_serializer.deserialize(&payload)?;
-        aggregate.set_version(version);
-        Ok(Some(SnapshotEnvelope {
-          aggregate,
-          seq_nr: seq_nr as usize,
-          version,
-        }))
+        // FR4.3 / U1 BR2.5: 読取後の set_version 補正は存在しない — version / seq_nr は列値を
+        // そのまま封筒に載せて返す（列型不整合・整数域逸脱は破損データとして読取エラー）。
+        // NFR2.5: 封筒の構築は SnapshotEnvelope::new の公開ビルダーのみで行う
+        let version = column_usize(version, "snapshot", "version")?;
+        let seq_nr = column_usize(seq_nr, "snapshot", "seq_nr")?;
+        let aggregate = self.snapshot_serializer.deserialize(&payload)?;
+        Ok(Some(SnapshotEnvelope::new(aggregate, seq_nr, version)))
       }
     }
   }
 
-  async fn fetch_events_since(&self, aid: &AID, seq_nr: usize) -> Result<Vec<E>, EventStoreReadError> {
-    let payloads: Vec<Vec<u8>> = {
+  async fn fetch_events_since(
+    &self,
+    aid: &AID,
+    seq_nr: usize,
+  ) -> Result<Vec<EventEnvelope<AID, P>>, EventStoreReadError> {
+    // BR2.2 / AC4.1.1 / FR5.1: 全列 SELECT から封筒を再構成する（payload 単独 SELECT の廃止）。
+    // 列欠落・型不整合は破損データとして読取エラーになる
+    let rows: Vec<(i64, i64, String, Vec<u8>)> = {
       let connection = self.lock_connection().map_err(EventStoreReadError::OtherError)?;
       let mut statement = connection
-        .prepare("SELECT payload FROM journal WHERE aid = ?1 AND seq_nr >= ?2 ORDER BY seq_nr ASC")
+        .prepare("SELECT seq_nr, occurred_at, manifest, payload FROM journal WHERE aid = ?1 AND seq_nr >= ?2 ORDER BY seq_nr ASC")
         .map_err(map_read_error)?;
       let rows = statement
-        .query_map(params![aid.to_string(), seq_nr as i64], |row| row.get::<_, Vec<u8>>(0))
+        .query_map(params![aid.to_string(), seq_nr as i64], |row| {
+          Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Vec<u8>>(3)?,
+          ))
+        })
         .map_err(map_read_error)?;
       rows.collect::<Result<_, _>>().map_err(map_read_error)?
     };
-    let mut events = Vec::with_capacity(payloads.len());
-    for payload in payloads {
-      events.push(*self.event_serializer.deserialize(&payload)?);
+    let mut events = Vec::with_capacity(rows.len());
+    for (seq_nr, occurred_at, manifest, payload) in rows {
+      // NFR2.5 / AC5.1.1: 封筒の構築は EventEnvelope::new + with_manifest の公開ビルダーのみで行う
+      let seq_nr = column_usize(seq_nr, "journal", "seq_nr")?;
+      let payload = self.event_serializer.deserialize(&payload)?;
+      events
+        .push(EventEnvelope::new(aid.clone(), seq_nr, parse_occurred_at(occurred_at), payload).with_manifest(manifest));
     }
     Ok(events)
   }
 
   async fn create_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: &A,
     maintenance: &SnapshotMaintenance,
   ) -> Result<(), EventStoreWriteError> {
@@ -358,33 +404,38 @@ where
     let aid = event.aggregate_id();
     let aid_string = aid.to_string();
     let pkey = self.resolve_pkey(aid);
-    let slot_skey = self.resolve_skey(aid, 0);
+    let slot_skey = self.current_slot_skey(aid);
+    // BR2.3 / AC2.3.3: payload は純ドメイン内容のみ（メタデータ注入つき直列化の廃止）。
+    // NFR2.5: 封筒の分解は公開アクセサのみで行う
     let snapshot_payload = self.snapshot_serializer.serialize(aggregate)?;
-    let event_payload = self.event_serializer.serialize(event)?;
-    let occurred_at = event.occurred_at().timestamp_millis();
-    let expected_version = aggregate.version();
+    let event_payload = self.event_serializer.serialize(event.payload())?;
+    let occurred_at = occurred_at_nanos(event.occurred_at())?;
+    let last_updated_at = event.occurred_at().timestamp_millis();
 
     let mut connection = self.lock_connection().map_err(EventStoreWriteError::OtherError)?;
     let tx = connection.transaction().map_err(map_write_error)?;
-    // 現行スロット（seq_nr=0）への挿入一意性が作成の重複を排除する（BR2.3）。
-    // 一意性違反時は実versionを読み取りBR1.2書式で返す（トランザクションはdropでロールバック）
+    // BR1.1 / AC2.2.1: 現行スロット行の INSERT 一意性（主キー衝突）が作成の重複を排除する（現行維持）。
+    // W1: version = 1（固定値）、seq_nr 列 = event.seq_nr()（実値 — BR2.4。旧実装のスロット位置 0 と
+    // aggregate.version() の列値流用は trait 廃止と共に消滅）。衝突時の expected_version は
+    // リテラル 0（U1 の新規作成規約 expected_version == 0 — BR1.1）で、実 version を追補読取して
+    // 統一書式で返す（トランザクションは drop でロールバック）
     let inserted = tx.execute(
       INSERT_SNAPSHOT_SQL,
       params![
         pkey,
         slot_skey,
         aid_string,
-        0i64,
-        expected_version as i64,
+        event.seq_nr() as i64,
+        1i64,
         snapshot_payload,
-        occurred_at
+        last_updated_at
       ],
     );
     if let Err(err) = inserted {
       if is_constraint_violation(&err) {
         let actual_version = read_slot_version(&tx, &pkey, &slot_skey)?;
         return Err(EventStoreWriteError::OptimisticLockError(
-          format_optimistic_lock_message(&aid_string, expected_version, actual_version),
+          format_optimistic_lock_message(&aid_string, 0, actual_version),
         ));
       }
       return Err(map_write_error(err));
@@ -398,28 +449,31 @@ where
         aid_string,
         event.seq_nr() as i64,
         event_payload,
-        occurred_at
+        occurred_at,
+        event.manifest()
       ],
       &aid_string,
-      expected_version,
+      // BR1.1: create パスの衝突 3 箇所すべてで expected_version はリテラル 0
+      0,
     )?;
-    // 保持設定時は履歴スナップショット行（skey=実seq_nr）も同一トランザクションで挿入する
-    // （保持数0は履歴を持たない設定のため挿入しない）
-    if maintenance.keep_snapshot_count.is_some_and(|count| count > 0) {
+    // BR3.1: keep_snapshot_count = Some(n) のときのみ履歴行（skey / seq_nr 列 = event.seq_nr() 由来、
+    // version = 1）を同一トランザクションで挿入する。Some(0) は U1 BR4.1 のビルダー拒否により
+    // 到達しないため、ガードは is_some() で足りる（旧実装の count > 0 条項の単純化）
+    if maintenance.keep_snapshot_count.is_some() {
       execute_write_mapping_conflict(
         &tx,
         INSERT_SNAPSHOT_SQL,
         params![
           pkey,
-          self.resolve_skey(aid, aggregate.seq_nr()),
+          self.resolve_skey(aid, event.seq_nr()),
           aid_string,
-          aggregate.seq_nr() as i64,
-          expected_version as i64,
+          event.seq_nr() as i64,
+          1i64,
           snapshot_payload,
-          occurred_at
+          last_updated_at
         ],
         &aid_string,
-        expected_version,
+        0,
       )?;
     }
     tx.commit().map_err(map_write_error)
@@ -427,7 +481,7 @@ where
 
   async fn update_event_and_snapshot(
     &self,
-    event: &E,
+    event: &EventEnvelope<AID, P>,
     aggregate: Option<&A>,
     expected_version: usize,
     maintenance: &SnapshotMaintenance,
@@ -436,35 +490,41 @@ where
     let aid = event.aggregate_id();
     let aid_string = aid.to_string();
     let pkey = self.resolve_pkey(aid);
-    let slot_skey = self.resolve_skey(aid, 0);
+    let slot_skey = self.current_slot_skey(aid);
+    // BR2.3 / AC2.3.3: payload は純ドメイン内容のみ
     let snapshot_payload = aggregate
       .map(|aggregate| self.snapshot_serializer.serialize(aggregate))
       .transpose()?;
-    let event_payload = self.event_serializer.serialize(event)?;
-    let occurred_at = event.occurred_at().timestamp_millis();
+    let event_payload = self.event_serializer.serialize(event.payload())?;
+    let occurred_at = occurred_at_nanos(event.occurred_at())?;
+    let last_updated_at = event.occurred_at().timestamp_millis();
 
     let mut connection = self.lock_connection().map_err(EventStoreWriteError::OtherError)?;
     let tx = connection.transaction().map_err(map_write_error)?;
-    // 単一トランザクション内のCAS: version=expected の条件付き更新（BR2.4）。
-    // スロット0行の seq_nr 列は 0 のまま維持する（DynamoDB参照実装と対称）
-    let affected = match (aggregate, &snapshot_payload) {
-      (Some(_), Some(payload)) => tx.execute(
-        "UPDATE snapshot SET payload = ?1, version = ?2, last_updated_at = ?3 WHERE pkey = ?4 AND skey = ?5 AND \
-         version = ?6",
+    // BR1.1 / NFR4.4 / AC2.2.1 / P10: 単一トランザクション内の条件付き UPDATE
+    // （WHERE version = expected）が唯一の競合判定点（現行維持）。version = expected + 1
+    // （明示値 — BR2.4）。スナップショット付き更新（aggregate あり）のみ payload / seq_nr 列
+    // （= event.seq_nr() 実値）も更新し、イベントのみ更新では集約状態が変わらないため
+    // 反映位置も不変として据え置く（BR2.4）
+    let affected = match &snapshot_payload {
+      Some(payload) => tx.execute(
+        "UPDATE snapshot SET payload = ?1, seq_nr = ?2, version = ?3, last_updated_at = ?4 WHERE pkey = ?5 AND skey = \
+         ?6 AND version = ?7",
         params![
           payload,
+          event.seq_nr() as i64,
           (expected_version + 1) as i64,
-          occurred_at,
+          last_updated_at,
           pkey,
           slot_skey,
           expected_version as i64
         ],
       ),
-      _ => tx.execute(
+      None => tx.execute(
         "UPDATE snapshot SET version = ?1, last_updated_at = ?2 WHERE pkey = ?3 AND skey = ?4 AND version = ?5",
         params![
           (expected_version + 1) as i64,
-          occurred_at,
+          last_updated_at,
           pkey,
           slot_skey,
           expected_version as i64
@@ -473,7 +533,8 @@ where
     }
     .map_err(map_write_error)?;
     if affected == 0 {
-      // 影響行0 = バージョン不一致（または未作成）。実versionを読み取りBR1.2書式で返す
+      // BR1.1: 変更行数 0 = version 不一致または不在集約。実 version を追補読取して統一書式で返す。
+      // 不在集約は actual_version なし書式になる（U1 リファレンス意味論 — AC2.2.1）
       let actual_version = read_slot_version(&tx, &pkey, &slot_skey)?;
       return Err(EventStoreWriteError::OptimisticLockError(
         format_optimistic_lock_message(&aid_string, expected_version, actual_version),
@@ -488,28 +549,26 @@ where
         aid_string,
         event.seq_nr() as i64,
         event_payload,
-        occurred_at
+        occurred_at,
+        event.manifest()
       ],
       &aid_string,
       expected_version,
     )?;
-    // 保持数0は履歴を持たない設定のため履歴行を挿入しない
-    if let (Some(aggregate), Some(payload), Some(_)) = (
-      aggregate,
-      &snapshot_payload,
-      maintenance.keep_snapshot_count.filter(|count| *count > 0),
-    ) {
+    // BR3.1 / BR2.4: 履歴行は keep_snapshot_count = Some(n) かつスナップショット付き更新のときのみ。
+    // skey / seq_nr 列 = event.seq_nr() 由来、version = expected + 1（明示値）
+    if let (Some(payload), Some(_)) = (&snapshot_payload, maintenance.keep_snapshot_count) {
       execute_write_mapping_conflict(
         &tx,
         INSERT_SNAPSHOT_SQL,
         params![
           pkey,
-          self.resolve_skey(aid, aggregate.seq_nr()),
+          self.resolve_skey(aid, event.seq_nr()),
           aid_string,
-          aggregate.seq_nr() as i64,
-          aggregate.version() as i64,
+          event.seq_nr() as i64,
+          (expected_version + 1) as i64,
           payload,
-          occurred_at
+          last_updated_at
         ],
         &aid_string,
         expected_version,
@@ -519,40 +578,43 @@ where
   }
 
   async fn on_event_persisted(&self, aid: &AID, maintenance: &SnapshotMaintenance) -> Result<(), EventStoreWriteError> {
-    // 保持ポリシーの実行点（BR2.7）。keep_snapshot_count 未設定なら何もしない。
-    // 保持数0は「履歴を残さない」設定として全履歴行を剪定し、delete_ttl も併せて適用する
+    // BR3.1 / AC2.3.4: 保持ポリシーの実行点（現行の剪定計算 + delete_ttl 併用を維持）。
+    // keep_snapshot_count = None は履歴行が書かれないため何もしない。Some(0) は
+    // U1 BR4.1 のビルダー拒否によりここへ到達しない（Some/None の分岐構造は現行維持）
     let keep_snapshot_count = match maintenance.keep_snapshot_count {
       Some(count) => count,
       None => return Ok(()),
     };
     let aid_string = aid.to_string();
+    // BR2.4: 履歴行の判別は skey != 現行スロット skey（主キー）で行う
+    // （seq_nr 列の実値化により、旧実装の「WHERE seq_nr > 0」列値判別は成立しない）
+    let slot_skey = self.current_slot_skey(aid);
     let expiration_cutoff = maintenance
       .delete_ttl
       .map(|delete_ttl| (Utc::now() - delete_ttl).timestamp_millis());
 
     let mut connection = self.lock_connection().map_err(EventStoreWriteError::OtherError)?;
     let tx = connection.transaction().map_err(map_write_error)?;
-    // 削除対象は履歴行（seq_nr > 0）のみ。現行スロット行（seq_nr = 0）は対象外
     let history_count: i64 = tx
       .query_row(
-        "SELECT COUNT(*) FROM snapshot WHERE aid = ?1 AND seq_nr > 0",
-        params![aid_string],
+        "SELECT COUNT(*) FROM snapshot WHERE aid = ?1 AND skey != ?2",
+        params![aid_string, slot_skey],
         |row| row.get(0),
       )
       .map_err(map_write_error)?;
     let excess_count = history_count - keep_snapshot_count as i64;
     if excess_count > 0 {
       tx.execute(
-        "DELETE FROM snapshot WHERE rowid IN (SELECT rowid FROM snapshot WHERE aid = ?1 AND seq_nr > 0 ORDER BY \
-         seq_nr ASC LIMIT ?2)",
-        params![aid_string, excess_count],
+        "DELETE FROM snapshot WHERE rowid IN (SELECT rowid FROM snapshot WHERE aid = ?1 AND skey != ?2 ORDER BY \
+         seq_nr ASC LIMIT ?3)",
+        params![aid_string, slot_skey, excess_count],
       )
       .map_err(map_write_error)?;
     }
     if let Some(cutoff) = expiration_cutoff {
       tx.execute(
-        "DELETE FROM snapshot WHERE aid = ?1 AND seq_nr > 0 AND last_updated_at < ?2",
-        params![aid_string, cutoff],
+        "DELETE FROM snapshot WHERE aid = ?1 AND skey != ?2 AND last_updated_at < ?3",
+        params![aid_string, slot_skey, cutoff],
       )
       .map_err(map_write_error)?;
     }
@@ -560,7 +622,28 @@ where
   }
 }
 
-/// 現行スロット行の実versionを読み取る（不存在は `None`）。
+// FR1.4 / U1 BR1.3 / C3: occurred_at はドメイン供給値のまま保存・読出しする。旧実装の epoch millis
+// 格納ではサブミリ秒精度が失われ供給値の完全往復（共有シナリオの occurred_at 同値 assert）を
+// 満たせないため、INTEGER 列へ epoch nanos（i64）で格納する（U2 dynamodb と同型の精度是正）。
+// i64 nanos の表現範囲外（およそ西暦 1677〜2262 年の外）は黙って切り詰めずエラーで拒否する（fail fast）
+fn occurred_at_nanos(occurred_at: &DateTime<Utc>) -> Result<i64, EventStoreWriteError> {
+  occurred_at
+    .timestamp_nanos_opt()
+    .ok_or_else(|| EventStoreWriteError::OtherError("occurred_at is out of the epoch-nanos range".to_string()))
+}
+
+fn parse_occurred_at(nanos: i64) -> DateTime<Utc> {
+  DateTime::from_timestamp_nanos(nanos)
+}
+
+// BR2.2: 整数列の負値は破損データとして読取エラーにする
+// （メッセージはテーブル種別と列名のみで、値・DBファイルパスは展開しない — NFR3.8）
+fn column_usize(value: i64, table: &'static str, column: &'static str) -> Result<usize, EventStoreReadError> {
+  usize::try_from(value)
+    .map_err(|_| EventStoreReadError::OtherError(format!("{} row column has an out-of-range value: {}", table, column)))
+}
+
+/// 現行スロット行の実versionを読み取る（不存在は `None` — actual_version なし書式の源）。
 fn read_slot_version(tx: &Transaction<'_>, pkey: &str, skey: &str) -> Result<Option<usize>, EventStoreWriteError> {
   tx.query_row(
     "SELECT version FROM snapshot WHERE pkey = ?1 AND skey = ?2",
@@ -573,7 +656,7 @@ fn read_slot_version(tx: &Transaction<'_>, pkey: &str, skey: &str) -> Result<Opt
 }
 
 /// トランザクション内の書き込みを実行し、一意性違反は楽観的ロック競合として写像する
-/// （DynamoDBのTransactWriteItemsキャンセル→OptimisticLockError写像と対称 — BR2.3/BR2.4）。
+/// （DynamoDBのTransactWriteItemsキャンセル→OptimisticLockError写像と対称 — BR1.1）。
 fn execute_write_mapping_conflict(
   tx: &Transaction<'_>,
   sql: &str,
@@ -594,10 +677,12 @@ fn is_constraint_violation(err: &rusqlite::Error) -> bool {
   matches!(err, rusqlite::Error::SqliteFailure(e, _) if e.code == ErrorCode::ConstraintViolation)
 }
 
-// rusqliteエラーの中立写像（BR2.8の決定表）: SQLiteエンジン起因の失敗（SQLITE_BUSY・
+// BR4.1 / NFR3.8 / P12: rusqliteエラーの中立写像。SQLiteエンジン起因の失敗（SQLITE_BUSY・
 // SQLITE_CANTOPEN 等）はIOError、それ以外（型変換等のAPI利用起因）はOtherError。
-// 楽観的ロック競合は呼び出し箇所で is_constraint_violation により先行判定するため、
-// 本写像には到達しない。生エラー詳細はソースエラー側にのみ保持する（メッセージ衛生）。
+// SQLITE_BUSY は即時 IOError で返し、リトライ・PRAGMA 調整を持ち込まない（NFR3.9 —
+// project.md Decided）。楽観的ロック競合は呼び出し箇所で is_constraint_violation により
+// 先行判定するため、本写像には到達しない。生エラー詳細はソースエラー側にのみ保持し、
+// 書式化メッセージへ DB ファイルパス以外の生詳細を展開しない（メッセージ衛生）。
 fn map_write_error(err: rusqlite::Error) -> EventStoreWriteError {
   match err {
     rusqlite::Error::SqliteFailure(_, _) => EventStoreWriteError::IOError(Box::new(err)),

--- a/lib/src/event_store_for_sqlite_test.rs
+++ b/lib/src/event_store_for_sqlite_test.rs
@@ -1,15 +1,21 @@
 use std::path::{Path, PathBuf};
 
+use chrono::Utc;
 use event_store_adapter_test_utils_rs::id_generator::id_generate;
 
+use crate::event_envelope::EventEnvelope;
 use crate::event_store_for_sqlite::EventStoreForSqlite;
 use crate::event_store_test_support::{
-  exercise_user_account_flow, find_by_id, init_tracing, UserAccount, UserAccountEvent, UserAccountId,
+  assert_optimistic_lock_message_format, exercise_user_account_flow, find_by_id, init_tracing, UserAccount,
+  UserAccountEvent, UserAccountId, CREATED_MANIFEST, RENAMED_MANIFEST,
 };
-use crate::types::{Aggregate, EventStore, EventStoreWriteError};
+use crate::key_resolver::{DefaultKeyResolver, KeyResolver};
+use crate::types::{EventStore, EventStoreReadError, EventStoreWriteError};
+
+type UserAccountStore = EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent>;
 
 // 一時ディレクトリ＋一意名のファイルDB。Dropで自テスト作成分のみ後始末する
-// （Docker/testcontainers不要・決定的・並列安全 — AC3.2.2）
+// （Docker/testcontainers不要・決定的・並列安全 — NFR6.8）
 struct TempDb {
   path: PathBuf,
 }
@@ -28,16 +34,67 @@ impl Drop for TempDb {
   }
 }
 
-fn new_file_event_store(path: &Path) -> EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent> {
+fn new_file_event_store(path: &Path) -> UserAccountStore {
   EventStoreForSqlite::new(path).expect("failed to open sqlite event store")
 }
 
+// バックエンドのキースキーム（DefaultKeyResolver の sort key）の複製。
+// スナップショット行の物理配置（現行スロット = skey マーカー 0 / 履歴 = skey seq_nr 修飾）を
+// 白箱検証するために使う（BR2.4 の skey 判別）
+fn snapshot_skey(id: &UserAccountId, seq_nr: usize) -> String {
+  let resolver = DefaultKeyResolver::<UserAccountId>::default();
+  resolver.resolve_sort_key(id, seq_nr)
+}
+
+fn current_snapshot_skey(id: &UserAccountId) -> String {
+  snapshot_skey(id, 0)
+}
+
+// ストア破棄後のDBファイルを直接開き、対象集約の snapshot 行 (skey, seq_nr, version, payload) を返す
+// （保持ポリシー・列実値は公開APIへ露出しないため、テストのみrusqliteで直接観測する）
+fn snapshot_rows(path: &Path, id: &UserAccountId) -> Vec<(String, i64, i64, Vec<u8>)> {
+  let connection = rusqlite::Connection::open(path).expect("failed to open db for inspection");
+  let mut statement = connection
+    .prepare("SELECT skey, seq_nr, version, payload FROM snapshot WHERE aid = ?1 ORDER BY seq_nr ASC")
+    .unwrap();
+  statement
+    .query_map(rusqlite::params![id.to_string()], |row| {
+      Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+    })
+    .unwrap()
+    .collect::<Result<Vec<_>, _>>()
+    .unwrap()
+}
+
+// 履歴行（skey != 現行スロット skey — BR2.4 の判別そのもの）の seq_nr 一覧を昇順で返す
+fn history_seq_nrs(rows: &[(String, i64, i64, Vec<u8>)], id: &UserAccountId) -> Vec<i64> {
+  let current_skey = current_snapshot_skey(id);
+  rows
+    .iter()
+    .filter(|(skey, _, _, _)| *skey != current_skey)
+    .map(|(_, seq_nr, _, _)| *seq_nr)
+    .collect()
+}
+
+fn created_envelope(id: &UserAccountId, payload: UserAccountEvent) -> EventEnvelope<UserAccountId, UserAccountEvent> {
+  EventEnvelope::new(id.clone(), 1, Utc::now(), payload).with_manifest(CREATED_MANIFEST)
+}
+
+fn renamed_envelope(
+  id: &UserAccountId,
+  seq_nr: usize,
+  payload: UserAccountEvent,
+) -> EventEnvelope<UserAccountId, UserAccountEvent> {
+  EventEnvelope::new(id.clone(), seq_nr, Utc::now(), payload).with_manifest(RENAMED_MANIFEST)
+}
+
+// FR7.1 / C3 / AC5.1.1: 共有シナリオ（8 手順・封筒メタデータ往復 assert 含む — occurred_at の
+// ナノ秒完全一致往復を含意）を無改変で green にする。空のDBファイルからのスキーマ自動作成も兼ねる
 #[tokio::test]
 async fn test_event_store_on_sqlite() {
   init_tracing();
 
   let db = TempDb::new();
-  // AC1.1.1: 空のDBファイルからスキーマ自動作成のうえ永続化・復元が成功する
   std::fs::File::create(&db.path).expect("failed to create empty db file");
   let mut event_store = new_file_event_store(&db.path);
   let id = UserAccountId::new(id_generate().to_string());
@@ -47,10 +104,10 @@ async fn test_event_store_on_sqlite() {
     .expect("scenario failed");
 }
 
+// C3: `:memory:` でも同一シナリオが同一挙動で green になる（ファイル/インメモリの対称性）
 #[tokio::test]
 async fn test_event_store_on_sqlite_in_memory() {
-  // AC1.3.1: `:memory:` でも同一インスタンス上で永続化・リプレイが一貫する
-  let mut event_store: EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent> =
+  let mut event_store: UserAccountStore =
     EventStoreForSqlite::new_in_memory().expect("failed to open in-memory sqlite event store");
   let id = UserAccountId::new(id_generate().to_string());
 
@@ -59,34 +116,43 @@ async fn test_event_store_on_sqlite_in_memory() {
     .expect("scenario failed");
 }
 
+// NFR3.9 の共有単位（1 ストアインスタンス + クローン）: Cloneは基底接続を共有し、
+// クローン間で書込みが相互に見える（状態分岐が存在しない）
 #[tokio::test]
 async fn test_event_store_on_sqlite_in_memory_clone_shares_state() {
-  let mut original: EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent> =
+  let mut original: UserAccountStore =
     EventStoreForSqlite::new_in_memory().expect("failed to open in-memory sqlite event store");
   let mut cloned = original.clone();
   let id = UserAccountId::new(id_generate().to_string());
   let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
   original
-    .persist_event_and_snapshot(&created, &user_account)
+    .persist_event_and_snapshot(created_envelope(&id, created), user_account, 0)
     .await
     .unwrap();
 
-  // AC1.3.1: クローン側から元の書込みが見える（Cloneは基底接続を共有 — BR2.5）
-  let mut from_clone = find_by_id(&mut cloned, &id)
+  // クローン側から元の書込みが見える
+  let from_clone = find_by_id(&cloned, &id)
     .await
     .unwrap()
     .expect("clone must see the original's write");
-  assert_eq!(from_clone.version(), 1);
+  assert_eq!(from_clone.version, 1);
+  assert_eq!(from_clone.seq_nr, 1);
 
-  // クローン側の書込みが元から見える（Clone間の状態分岐が存在しない）
-  let event = from_clone.rename("renamed-via-clone").unwrap();
-  cloned.persist_event(&event, from_clone.version()).await.unwrap();
+  // クローン側の書込みが元から見える
+  let mut state = from_clone.state;
+  let event = state.rename("renamed-via-clone").unwrap();
+  cloned
+    .persist_event(renamed_envelope(&id, from_clone.seq_nr + 1, event), from_clone.version)
+    .await
+    .unwrap();
 
-  let from_original = find_by_id(&mut original, &id).await.unwrap().unwrap();
-  assert_eq!(from_original.version(), 2);
-  assert_eq!(from_original.seq_nr(), 2);
+  let from_original = find_by_id(&original, &id).await.unwrap().unwrap();
+  assert_eq!(from_original.version, 2);
+  assert_eq!(from_original.seq_nr, 2);
+  assert_eq!(from_original.state.name, "renamed-via-clone");
 }
 
+// ストアを破棄してファイルから再構築しても状態が復元される（永続化の実体検証）
 #[tokio::test]
 async fn test_event_store_on_sqlite_file_reopen_restores_state() {
   let db = TempDb::new();
@@ -95,24 +161,31 @@ async fn test_event_store_on_sqlite_file_reopen_restores_state() {
     let mut event_store = new_file_event_store(&db.path);
     let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
     event_store
-      .persist_event_and_snapshot(&created, &user_account)
+      .persist_event_and_snapshot(created_envelope(&id, created), user_account, 0)
       .await
       .unwrap();
-    let mut account = find_by_id(&mut event_store, &id).await.unwrap().unwrap();
-    let event = account.rename("renamed-before-reopen").unwrap();
-    event_store.persist_event(&event, account.version()).await.unwrap();
+    let account = find_by_id(&event_store, &id).await.unwrap().unwrap();
+    let mut state = account.state;
+    let event = state.rename("renamed-before-reopen").unwrap();
+    event_store
+      .persist_event(renamed_envelope(&id, account.seq_nr + 1, event), account.version)
+      .await
+      .unwrap();
   }
 
-  // AC1.3.2: ストアを破棄してファイルから再構築しても状態が復元される
-  let mut reopened = new_file_event_store(&db.path);
-  let restored = find_by_id(&mut reopened, &id)
+  let reopened = new_file_event_store(&db.path);
+  let restored = find_by_id(&reopened, &id)
     .await
     .unwrap()
     .expect("state must survive store reconstruction");
-  assert_eq!(restored.version(), 2);
-  assert_eq!(restored.seq_nr(), 2);
+  assert_eq!(restored.version, 2);
+  assert_eq!(restored.seq_nr, 2);
+  assert_eq!(restored.state.name, "renamed-before-reopen");
 }
 
+// NFR4.4 / AC2.2.1 / BR1.1: 同一 expected_version からの後発書込みは決定的に
+// OptimisticLockError で失敗する（トランザクション内条件付き UPDATE が唯一の競合判定点 — P10）。
+// 失敗した書込みはロールバックされ journal に残骸を残さない
 #[tokio::test]
 async fn test_event_store_on_sqlite_optimistic_lock_conflict() {
   let db = TempDb::new();
@@ -122,7 +195,7 @@ async fn test_event_store_on_sqlite_optimistic_lock_conflict() {
   {
     let mut writer = store.clone();
     writer
-      .persist_event_and_snapshot(&created, &user_account)
+      .persist_event_and_snapshot(created_envelope(&id, created), user_account, 0)
       .await
       .unwrap();
   }
@@ -130,29 +203,41 @@ async fn test_event_store_on_sqlite_optimistic_lock_conflict() {
   // 同一DBを共有する2ハンドル（Cloneは基底接続共有）で同一バージョンから順次コミットする
   let mut store_a = store.clone();
   let mut store_b = store.clone();
-  let mut account_a = find_by_id(&mut store_a, &id).await.unwrap().unwrap();
-  let mut account_b = find_by_id(&mut store_b, &id).await.unwrap().unwrap();
+  let mut account_a = find_by_id(&store_a, &id).await.unwrap().unwrap();
+  let mut account_b = find_by_id(&store_b, &id).await.unwrap().unwrap();
 
-  let event_a = account_a.rename("first").unwrap();
-  store_a.persist_event(&event_a, account_a.version()).await.unwrap();
+  let event_a = account_a.state.rename("first").unwrap();
+  store_a
+    .persist_event(renamed_envelope(&id, account_a.seq_nr + 1, event_a), account_a.version)
+    .await
+    .unwrap();
 
-  // AC1.2.1: 後発の同一バージョンへの書込みは決定的に OptimisticLockError で失敗する
-  let event_b = account_b.rename("second").unwrap();
-  let result = store_b.persist_event(&event_b, account_b.version()).await;
-  assert!(
-    matches!(result, Err(EventStoreWriteError::OptimisticLockError(_))),
-    "expected OptimisticLockError, got {:?}",
-    result
-  );
+  let event_b = account_b.state.rename("second").unwrap();
+  let result = store_b
+    .persist_event(renamed_envelope(&id, account_b.seq_nr + 1, event_b), account_b.version)
+    .await;
+  match result {
+    Err(EventStoreWriteError::OptimisticLockError(message)) => {
+      assert!(
+        message.starts_with(&format!("optimistic lock failed, aid={}, expected_version=1", id)),
+        "unexpected message: {}",
+        message
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
 
-  // AC1.2.2: 失敗した書込みはロールバックされ journal に残骸を残さない（勝者のイベントのみ）
+  // 失敗した書込みはロールバックされ journal に残骸を残さない（勝者のイベントのみ）
   let events = store_a.get_events_by_id_since_seq_nr(&id, 0).await.unwrap();
   assert_eq!(events.len(), 2);
-  let replayed = find_by_id(&mut store_a, &id).await.unwrap().unwrap();
-  assert_eq!(replayed.version(), 2);
-  assert_eq!(replayed.seq_nr(), 2);
+  let replayed = find_by_id(&store_a, &id).await.unwrap().unwrap();
+  assert_eq!(replayed.version, 2);
+  assert_eq!(replayed.seq_nr, 2);
 }
 
+// NFR4.4 / BR1.1: エラー契約の回帰固定 — 更新競合は actual_version 付き、既存集約への重複作成は
+// create パスの expected_version リテラル 0 + actual_version 付きの統一書式で返る
 #[tokio::test]
 async fn test_event_store_on_sqlite_error_contract() {
   let db = TempDb::new();
@@ -161,36 +246,23 @@ async fn test_event_store_on_sqlite_error_contract() {
   let id = UserAccountId::new(id_generate().to_string());
   let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
   store_a
-    .persist_event_and_snapshot(&created, &user_account)
+    .persist_event_and_snapshot(created_envelope(&id, created), user_account, 0)
     .await
     .unwrap();
 
-  let mut account_a = find_by_id(&mut store_a, &id).await.unwrap().unwrap();
-  let mut account_b = find_by_id(&mut store_b, &id).await.unwrap().unwrap();
+  let mut account_a = find_by_id(&store_a, &id).await.unwrap().unwrap();
+  let mut account_b = find_by_id(&store_b, &id).await.unwrap().unwrap();
 
-  let event_a = account_a.rename("first").unwrap();
-  store_a.persist_event(&event_a, account_a.version()).await.unwrap();
+  let event_a = account_a.state.rename("first").unwrap();
+  store_a
+    .persist_event(renamed_envelope(&id, account_a.seq_nr + 1, event_a), account_a.version)
+    .await
+    .unwrap();
 
-  // AC3.2.3: 同一バージョン(1)への後発の書込みは actual_version 付きBR1.2書式で失敗する
-  let event_b = account_b.rename("second").unwrap();
-  let result = store_b.persist_event(&event_b, account_b.version()).await;
-  match result {
-    Err(EventStoreWriteError::OptimisticLockError(message)) => {
-      assert_eq!(
-        message,
-        format!(
-          "optimistic lock failed, aid={}, expected_version=1, actual_version=2",
-          id
-        )
-      );
-    }
-    other => panic!("expected OptimisticLockError, got {:?}", other),
-  }
-
-  // BR2.3: 既存集約への重複作成もBR1.2書式の OptimisticLockError（AWS型リーク・panicなし）
-  let (duplicate_account, duplicate_created) = UserAccount::new(id.clone(), "duplicate".to_string());
+  // 同一バージョン(1)への後発の書込みは actual_version 付き統一書式で失敗する
+  let event_b = account_b.state.rename("second").unwrap();
   let result = store_b
-    .persist_event_and_snapshot(&duplicate_created, &duplicate_account)
+    .persist_event(renamed_envelope(&id, account_b.seq_nr + 1, event_b), account_b.version)
     .await;
   match result {
     Err(EventStoreWriteError::OptimisticLockError(message)) => {
@@ -201,137 +273,263 @@ async fn test_event_store_on_sqlite_error_contract() {
           id
         )
       );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
+
+  // BR1.1: 既存集約への重複作成は主キー衝突 → expected_version はリテラル 0（U1 の新規作成規約）
+  let (duplicate_account, duplicate_created) = UserAccount::new(id.clone(), "duplicate".to_string());
+  let result = store_b
+    .persist_event_and_snapshot(created_envelope(&id, duplicate_created), duplicate_account, 0)
+    .await;
+  match result {
+    Err(EventStoreWriteError::OptimisticLockError(message)) => {
+      assert_eq!(
+        message,
+        format!(
+          "optimistic lock failed, aid={}, expected_version=0, actual_version=2",
+          id
+        )
+      );
+      assert_optimistic_lock_message_format(&message);
     }
     other => panic!("expected OptimisticLockError, got {:?}", other),
   }
 }
 
-// ストア破棄後のDBファイルを直接開き、スナップショット行の (seq_nr=0スロット, 履歴) 件数を数える
-// （保持ポリシーは公開APIへ露出しないため、テストのみrusqliteで直接観測する）
-fn count_snapshot_rows(path: &Path, id: &UserAccountId) -> (i64, Vec<i64>) {
-  let connection = rusqlite::Connection::open(path).expect("failed to open db for inspection");
-  let slot_count: i64 = connection
-    .query_row(
-      "SELECT COUNT(*) FROM snapshot WHERE aid = ?1 AND seq_nr = 0",
-      rusqlite::params![id.to_string()],
-      |row| row.get(0),
-    )
-    .unwrap();
-  let mut statement = connection
-    .prepare("SELECT seq_nr FROM snapshot WHERE aid = ?1 AND seq_nr > 0 ORDER BY seq_nr ASC")
-    .unwrap();
-  let history_seq_nrs = statement
-    .query_map(rusqlite::params![id.to_string()], |row| row.get::<_, i64>(0))
-    .unwrap()
-    .collect::<Result<Vec<_>, _>>()
-    .unwrap();
-  (slot_count, history_seq_nrs)
-}
-
+// BR3.1 / AC2.3.4: keep_snapshot_count = Some(n) でスナップショット付き更新を繰り返すと
+// 履歴行が同一トランザクションで書かれ、保持フックが新しい順に n 件残して剪定する
+// （skey 判別への置換後も件数意味論が保たれる — BR2.4）。
+// AC2.3.3 / BR2.3: 現行・履歴行の payload は純ドメイン内容のみ（JSON 完全一致 — U2/U3 同型）。
+// BR2.4: 現行スロット行の seq_nr 列は実イベント位置を持つ（白箱で固定）
 #[tokio::test]
 async fn test_event_store_on_sqlite_snapshot_retention() {
   let db = TempDb::new();
   let id = UserAccountId::new(id_generate().to_string());
   {
-    // AC1.4.1: keep_snapshot_count=1 では古い履歴スナップショット行が残らない
-    let mut event_store = new_file_event_store(&db.path).with_keep_snapshot_count(Some(1));
+    let mut event_store = new_file_event_store(&db.path)
+      .with_keep_snapshot_count(Some(2))
+      .expect("Some(2) is valid");
     let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
     event_store
-      .persist_event_and_snapshot(&created, &user_account)
+      .persist_event_and_snapshot(created_envelope(&id, created), user_account.clone(), 0)
       .await
       .unwrap();
-    let mut account = find_by_id(&mut event_store, &id).await.unwrap().unwrap();
-    let event = account.rename("renamed-once").unwrap();
-    event_store.persist_event_and_snapshot(&event, &account).await.unwrap();
+
+    // スナップショット付き更新 × 3（履歴行は seq_nr = 1, 2, 3, 4 の 4 件生まれ、2 件へ剪定される）
+    let mut state = user_account;
+    for (seq_nr, name) in [(2_usize, "history-1"), (3, "history-2"), (4, "history-3")] {
+      let event = state.rename(name).unwrap();
+      event_store
+        .persist_event_and_snapshot(renamed_envelope(&id, seq_nr, event), state.clone(), seq_nr - 1)
+        .await
+        .unwrap();
+    }
   }
 
-  let (slot_count, history_seq_nrs) = count_snapshot_rows(&db.path, &id);
-  // 現行スロット行（seq_nr=0）は削除対象外
-  assert_eq!(slot_count, 1);
-  // 履歴は最新1件（seq_nr=2）のみ。作成時の履歴行（seq_nr=1）は保守で削除済み
-  assert_eq!(history_seq_nrs, vec![2]);
+  let rows = snapshot_rows(&db.path, &id);
+  // 現行スロット行は skey マーカーで 1 件のみ、seq_nr 列は実値 4・version は 4（BR2.4）
+  let current_skey = current_snapshot_skey(&id);
+  let current_rows: Vec<_> = rows.iter().filter(|(skey, _, _, _)| *skey == current_skey).collect();
+  assert_eq!(current_rows.len(), 1);
+  assert_eq!(current_rows[0].1, 4);
+  assert_eq!(current_rows[0].2, 4);
+
+  // 履歴は新しい順に 2 件（seq_nr = 3, 4）のみ。古い履歴行（seq_nr = 1, 2）は剪定済み
+  assert_eq!(history_seq_nrs(&rows, &id), vec![3, 4]);
+
+  // AC2.3.3: 現行スロット行の payload は純ドメイン内容のみ（version / seq_nr / last_updated_at の複製なし）
+  let current_json: serde_json::Value = serde_json::from_slice(&current_rows[0].3).unwrap();
+  let expected_current = UserAccount {
+    id: id.clone(),
+    name: "history-3".to_string(),
+  };
+  assert_eq!(current_json, serde_json::to_value(&expected_current).unwrap());
+
+  // 履歴行（seq_nr = 3 のスナップショット付き更新の後像）の payload も純ドメイン内容のみ
+  let history_payload = rows
+    .iter()
+    .find(|(skey, _, _, _)| *skey == snapshot_skey(&id, 3))
+    .map(|(_, _, _, payload)| payload)
+    .expect("history row for seq_nr 3 must exist");
+  let history_json: serde_json::Value = serde_json::from_slice(history_payload).unwrap();
+  let expected_history = UserAccount {
+    id: id.clone(),
+    name: "history-2".to_string(),
+  };
+  assert_eq!(history_json, serde_json::to_value(&expected_history).unwrap());
 }
 
+// BR3.1: delete_ttl 経過後の保持フックで期限切れ履歴行が削除される
+// （keep_snapshot_count=10 は超過削除を発火させないための値 — TTL削除だけを観測する）
 #[tokio::test]
 async fn test_event_store_on_sqlite_snapshot_ttl_expiration() {
   let db = TempDb::new();
   let id = UserAccountId::new(id_generate().to_string());
   {
-    // AC1.4.2: delete_ttl 経過後の保守フックで期限切れ履歴行が削除される
-    // （keep_snapshot_count=10 は超過削除を発火させないための値 — TTL削除だけを観測する）
     let mut event_store = new_file_event_store(&db.path)
       .with_keep_snapshot_count(Some(10))
+      .expect("Some(10) is valid")
       .with_delete_ttl(Some(chrono::Duration::milliseconds(500)));
     let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
     event_store
-      .persist_event_and_snapshot(&created, &user_account)
+      .persist_event_and_snapshot(created_envelope(&id, created), user_account.clone(), 0)
       .await
       .unwrap();
 
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
-    let mut account = find_by_id(&mut event_store, &id).await.unwrap().unwrap();
-    let event = account.rename("renamed-after-ttl").unwrap();
-    event_store.persist_event_and_snapshot(&event, &account).await.unwrap();
+    let mut state = user_account;
+    let event = state.rename("renamed-after-ttl").unwrap();
+    event_store
+      .persist_event_and_snapshot(renamed_envelope(&id, 2, event), state, 1)
+      .await
+      .unwrap();
   }
 
-  let (slot_count, history_seq_nrs) = count_snapshot_rows(&db.path, &id);
-  // 現行スロット行（seq_nr=0）は削除対象外
-  assert_eq!(slot_count, 1);
+  let rows = snapshot_rows(&db.path, &id);
+  // 現行スロット行（skey マーカー）は削除対象外
+  let current_skey = current_snapshot_skey(&id);
+  assert_eq!(rows.iter().filter(|(skey, _, _, _)| *skey == current_skey).count(), 1);
   // 作成時の履歴行（seq_nr=1）はTTL期限切れで削除され、直近の履歴行（seq_nr=2）のみ残る
-  assert_eq!(history_seq_nrs, vec![2]);
+  assert_eq!(history_seq_nrs(&rows, &id), vec![2]);
 }
 
+// AC2.2.2 / AC4.1.3 / BR4.1: 書込・読取のいずれの失敗経路でも panic せず
+// バックエンド中立なエラーが返る（NFR3.8 — 生エラー詳細の書式化展開なし）
 #[tokio::test]
 async fn test_event_store_on_sqlite_write_failure_returns_neutral_error() {
-  // AC1.1.4: 書き込み不能パスでも panic せずバックエンド中立なエラーを返す
+  // 書込経路: 存在しないディレクトリ配下のDBファイルは IOError（AC2.2.2）
   let missing_dir = std::env::temp_dir().join(format!("event-store-adapter-rs-missing-{}", id_generate()));
-  let result: Result<EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent>, _> =
-    EventStoreForSqlite::new(missing_dir.join("db.sqlite"));
+  let result: Result<UserAccountStore, _> = EventStoreForSqlite::new(missing_dir.join("db.sqlite"));
   match result {
     Err(EventStoreWriteError::IOError(_)) => {}
     other => panic!("expected IOError, got {:?}", other.map(|_| "Ok(store)")),
   }
-}
 
-#[tokio::test]
-async fn test_event_store_on_sqlite_snapshot_retention_zero() {
+  // 読取経路: 列型が破損した journal 行は panic せず EventStoreReadError になる（AC4.1.3 / BR2.2）
   let db = TempDb::new();
+  let store = new_file_event_store(&db.path);
   let id = UserAccountId::new(id_generate().to_string());
   {
-    // keep_snapshot_count=0 は「履歴を残さない」設定: 履歴行は挿入されず、既存分も剪定される
-    let mut event_store = new_file_event_store(&db.path).with_keep_snapshot_count(Some(0));
-    let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
-    event_store
-      .persist_event_and_snapshot(&created, &user_account)
-      .await
-      .unwrap();
-    let mut account = find_by_id(&mut event_store, &id).await.unwrap().unwrap();
-    let event = account.rename("renamed-once").unwrap();
-    event_store.persist_event_and_snapshot(&event, &account).await.unwrap();
+    let connection = rusqlite::Connection::open(&db.path).expect("failed to open db for corruption");
+    connection
+      .execute(
+        "INSERT INTO journal (pkey, skey, aid, seq_nr, payload, occurred_at, manifest) VALUES (?1, ?2, ?3, ?4, ?5, \
+         ?6, ?7)",
+        rusqlite::params!["p", "s", id.to_string(), 1i64, b"{}".to_vec(), "not-a-number", ""],
+      )
+      .expect("failed to insert corrupted row");
   }
-
-  let (slot_count, history_seq_nrs) = count_snapshot_rows(&db.path, &id);
-  // 現行スロット行（seq_nr=0）は保持し続ける
-  assert_eq!(slot_count, 1);
-  // 履歴行（seq_nr > 0）は一切残らない
-  assert!(history_seq_nrs.is_empty());
+  let result = store.get_events_by_id_since_seq_nr(&id, 0).await;
+  match result {
+    Err(EventStoreReadError::OtherError(_)) => {}
+    other => panic!("expected OtherError, got {:?}", other),
+  }
 }
 
+// BR4.1(U1) / P3: keep_snapshot_count = Some(0) はビルダーで拒否される（ラッパーの Result 素通し。
+// 旧実装の「Some(0) = 全履歴剪定」という暗黙挙動は入力値ごと到達不能になった）
+#[tokio::test]
+async fn test_event_store_on_sqlite_with_keep_snapshot_count_zero_is_rejected() {
+  let store: UserAccountStore =
+    EventStoreForSqlite::new_in_memory().expect("failed to open in-memory sqlite event store");
+  let result = store.with_keep_snapshot_count(Some(0));
+  assert!(matches!(result, Err(EventStoreWriteError::ContractViolation(_))));
+
+  let store: UserAccountStore =
+    EventStoreForSqlite::new_in_memory().expect("failed to open in-memory sqlite event store");
+  let store = store.with_keep_snapshot_count(Some(1)).expect("Some(1) is valid");
+  assert_eq!(store.maintenance().keep_snapshot_count, Some(1));
+}
+
+// BR4.1: shard_count=0 はキー解決のゼロ除算panicではなく、バックエンド中立なエラーで拒否される
 #[tokio::test]
 async fn test_event_store_on_sqlite_zero_shard_count_returns_neutral_error() {
-  // shard_count=0 はキー解決のゼロ除算panicではなく、バックエンド中立なエラーで拒否される
-  let mut event_store: EventStoreForSqlite<UserAccountId, UserAccount, UserAccountEvent> =
-    EventStoreForSqlite::new_in_memory()
-      .expect("failed to open in-memory sqlite event store")
-      .with_shard_count(0);
-  let (user_account, created) = UserAccount::new(UserAccountId::new(id_generate().to_string()), "test".to_string());
+  let mut event_store: UserAccountStore = EventStoreForSqlite::new_in_memory()
+    .expect("failed to open in-memory sqlite event store")
+    .with_shard_count(0);
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
 
-  let result = event_store.persist_event_and_snapshot(&created, &user_account).await;
+  let result = event_store
+    .persist_event_and_snapshot(created_envelope(&id, created), user_account, 0)
+    .await;
   match result {
     Err(EventStoreWriteError::OtherError(message)) => {
       assert!(message.contains("shard_count"));
     }
     other => panic!("expected OtherError, got {:?}", other),
   }
+}
+
+// U1 リファレンス意味論との対称性: 未作成（Absent）の集約への更新系呼び出しは
+// actual_version なし書式の OptimisticLockError を返す（条件付き UPDATE の変更行数 0 +
+// 追補 SELECT の行不在 — BR1.1 / AC2.2.1）
+#[tokio::test]
+async fn test_event_store_on_sqlite_update_on_absent_aggregate_yields_optimistic_lock_error() {
+  let mut store: UserAccountStore =
+    EventStoreForSqlite::new_in_memory().expect("failed to open in-memory sqlite event store");
+  let id = UserAccountId::new(id_generate().to_string());
+  let (user_account, _created) = UserAccount::new(id.clone(), "test".to_string());
+
+  // 未作成のまま seq_nr=2 / expected_version=1 のスナップショット付き更新（W3 経路）を呼ぶ
+  let envelope = EventEnvelope::new(
+    id.clone(),
+    2,
+    Utc::now(),
+    UserAccountEvent::Renamed {
+      name: "ghost".to_string(),
+    },
+  );
+  let result = store.persist_event_and_snapshot(envelope, user_account, 1).await;
+  match result {
+    Err(EventStoreWriteError::OptimisticLockError(message)) => {
+      // actual_version を含まない書式であることを完全一致で固定する
+      assert_eq!(
+        message,
+        format!("optimistic lock failed, aid={}, expected_version=1", id)
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
+}
+
+// BR3.1 / AC2.3.4: keep_snapshot_count = None（既定）は履歴行を書かず剪定もしない
+// （剪定なし設定に書込み増幅を持ち込まない — U2/U3 対称）
+#[tokio::test]
+async fn test_event_store_on_sqlite_without_keep_snapshot_count_writes_no_history() {
+  let db = TempDb::new();
+  let id = UserAccountId::new(id_generate().to_string());
+  {
+    let mut event_store = new_file_event_store(&db.path);
+    let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+    event_store
+      .persist_event_and_snapshot(created_envelope(&id, created), user_account.clone(), 0)
+      .await
+      .unwrap();
+
+    let mut state = user_account;
+    for (seq_nr, name) in [(2_usize, "no-history-1"), (3, "no-history-2")] {
+      let event = state.rename(name).unwrap();
+      event_store
+        .persist_event_and_snapshot(renamed_envelope(&id, seq_nr, event), state.clone(), seq_nr - 1)
+        .await
+        .unwrap();
+    }
+  }
+
+  let rows = snapshot_rows(&db.path, &id);
+  assert!(
+    history_seq_nrs(&rows, &id).is_empty(),
+    "no history rows must be written when keep_snapshot_count is None"
+  );
+  // 現行スロット行は最新状態を保持する
+  let current_skey = current_snapshot_skey(&id);
+  let current_rows: Vec<_> = rows.iter().filter(|(skey, _, _, _)| *skey == current_skey).collect();
+  assert_eq!(current_rows.len(), 1);
+  assert_eq!(current_rows[0].1, 3);
+  assert_eq!(current_rows[0].2, 3);
 }

--- a/lib/src/event_store_test_support.rs
+++ b/lib/src/event_store_test_support.rs
@@ -3,12 +3,21 @@
 use std::error::Error as StdError;
 use std::fmt::{Display, Formatter};
 
-use chrono::{DateTime, Utc};
-use event_store_adapter_test_utils_rs::id_generator::id_generate;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use ulid_generator_rs::ULID;
 
-use crate::types::{Aggregate, AggregateId, Event, EventStore};
+use crate::event_envelope::EventEnvelope;
+use crate::types::{AggregateId, EventStore, EventStoreWriteError};
+
+// FR7.1 / C3: 4 バックエンド共通の契約対称性ハーネス（v3 再設計版）。
+// 全バックエンドが本シナリオを無改変で green にすることが受入条件となる。
+// 旧シナリオの `user_account.seq_nr` / `user_account.version` への直接 assert
+// （集約フィールド依存）は封筒アクセサ経由に置き換えた（BR2.5 — set_version 廃止の帰結）。
+
+/// 手順 1（作成）で封筒に載せる manifest 値。
+pub const CREATED_MANIFEST: &str = "user-account-created/v1";
+/// 手順 3（リネーム）で封筒に載せる manifest 値。
+pub const RENAMED_MANIFEST: &str = "user-account-renamed/v1";
 
 #[derive(Debug)]
 pub enum UserAccountError {
@@ -42,100 +51,36 @@ impl AggregateId for UserAccountId {
   }
 }
 
+/// イベント payload（純ドメイン内容 — メタデータは封筒が運搬する。BR2.4）。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum UserAccountEvent {
-  Created {
-    id: ULID,
-    aggregate_id: UserAccountId,
-    seq_nr: usize,
-    name: String,
-    occurred_at: DateTime<Utc>,
-  },
-  Renamed {
-    id: ULID,
-    aggregate_id: UserAccountId,
-    seq_nr: usize,
-    name: String,
-    occurred_at: DateTime<Utc>,
-  },
+  Created { name: String },
+  Renamed { name: String },
 }
 
-impl Event for UserAccountEvent {
-  type AggregateID = UserAccountId;
-  type ID = ULID;
-
-  fn id(&self) -> &Self::ID {
-    match self {
-      UserAccountEvent::Created { id, .. } => id,
-      UserAccountEvent::Renamed { id, .. } => id,
-    }
-  }
-
-  fn aggregate_id(&self) -> &Self::AggregateID {
-    match self {
-      UserAccountEvent::Created { aggregate_id, .. } => aggregate_id,
-      UserAccountEvent::Renamed { aggregate_id, .. } => aggregate_id,
-    }
-  }
-
-  fn seq_nr(&self) -> usize {
-    match self {
-      UserAccountEvent::Created { seq_nr, .. } => *seq_nr,
-      UserAccountEvent::Renamed { seq_nr, .. } => *seq_nr,
-    }
-  }
-
-  fn occurred_at(&self) -> &DateTime<Utc> {
-    match self {
-      UserAccountEvent::Created { occurred_at, .. } => occurred_at,
-      UserAccountEvent::Renamed { occurred_at, .. } => occurred_at,
-    }
-  }
-
-  fn is_created(&self) -> bool {
-    matches!(self, UserAccountEvent::Created { .. })
-  }
-}
-
+/// 集約 payload（純ドメイン状態 — seq_nr / version / last_updated_at を持たない。FR3.2）。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UserAccount {
-  id: UserAccountId,
-  name: String,
-  seq_nr: usize,
-  version: usize,
-  last_updated_at: DateTime<Utc>,
+  pub id: UserAccountId,
+  pub name: String,
 }
 
 impl UserAccount {
   pub fn new(id: UserAccountId, name: String) -> (Self, UserAccountEvent) {
-    let mut my_self = Self {
-      id: id.clone(),
-      name,
-      seq_nr: 0,
-      version: 1,
-      last_updated_at: Utc::now(),
-    };
-    my_self.seq_nr += 1;
-    let event = UserAccountEvent::Created {
-      id: id_generate(),
-      aggregate_id: id,
-      seq_nr: my_self.seq_nr,
-      name: my_self.name.clone(),
-      occurred_at: Utc::now(),
-    };
-    (my_self, event)
+    let my_self = Self { id, name: name.clone() };
+    (my_self, UserAccountEvent::Created { name })
   }
 
-  fn replay(events: impl IntoIterator<Item = UserAccountEvent>, snapshot: UserAccount) -> Self {
+  pub fn replay(events: impl IntoIterator<Item = UserAccountEvent>, snapshot: UserAccount) -> Self {
     events.into_iter().fold(snapshot, |mut result, event| {
-      result.apply_event(event);
+      result.apply_event(&event);
       result
     })
   }
 
-  fn apply_event(&mut self, event: UserAccountEvent) {
-    if let UserAccountEvent::Renamed { name, .. } = event {
-      self.rename(&name).unwrap();
+  fn apply_event(&mut self, event: &UserAccountEvent) {
+    if let UserAccountEvent::Renamed { name } = event {
+      self.name = name.clone();
     }
   }
 
@@ -144,90 +89,185 @@ impl UserAccount {
       return Err(UserAccountError::AlreadyRenamed(name.to_string()));
     }
     self.name = name.to_string();
-    self.seq_nr += 1;
-    let event = UserAccountEvent::Renamed {
-      id: id_generate(),
-      aggregate_id: self.id.clone(),
-      seq_nr: self.seq_nr,
-      name: name.to_string(),
-      occurred_at: Utc::now(),
-    };
-    Ok(event)
+    Ok(UserAccountEvent::Renamed { name: name.to_string() })
   }
 }
 
-impl Aggregate for UserAccount {
-  type ID = UserAccountId;
-
-  fn id(&self) -> &Self::ID {
-    &self.id
-  }
-
-  fn seq_nr(&self) -> usize {
-    self.seq_nr
-  }
-
-  fn version(&self) -> usize {
-    self.version
-  }
-
-  fn set_version(&mut self, version: usize) {
-    self.version = version
-  }
-
-  fn last_updated_at(&self) -> &DateTime<Utc> {
-    &self.last_updated_at
-  }
+/// スナップショット + 差分リプレイ（W4）で復元した読取結果。
+///
+/// seq_nr / version は封筒（列由来）の値であり、集約フィールドへの書き戻しに依存しない
+/// （AC3.1.2）。次のイベントの採番は `seq_nr + 1`、次回書込の expected_version は `version`。
+pub struct ReplayedUserAccount {
+  pub state: UserAccount,
+  pub seq_nr: usize,
+  pub version: usize,
 }
 
+/// スナップショット封筒の seq_nr をリプレイ開始点として最新状態を復元する（W4）。
 pub async fn find_by_id<T>(
-  event_store: &mut T,
+  event_store: &T,
   id: &UserAccountId,
-) -> Result<Option<UserAccount>, Box<dyn StdError + Send + Sync>>
+) -> Result<Option<ReplayedUserAccount>, Box<dyn StdError + Send + Sync>>
 where
-  T: EventStore<AID = UserAccountId, AG = UserAccount, EV = UserAccountEvent>, {
-  let snapshot = event_store.get_latest_snapshot_by_id(id).await?;
-  match snapshot {
-    Some(snapshot) => {
-      let events = event_store
-        .get_events_by_id_since_seq_nr(id, snapshot.seq_nr() + 1)
-        .await?;
-      let user_account = UserAccount::replay(events, snapshot);
-      Ok(Some(user_account))
-    }
-    None => Ok(None),
-  }
+  T: EventStore<AID = UserAccountId, A = UserAccount, P = UserAccountEvent>, {
+  let snapshot = match event_store.get_latest_snapshot_by_id(id).await? {
+    Some(snapshot) => snapshot,
+    None => return Ok(None),
+  };
+  let snapshot_seq_nr = snapshot.seq_nr();
+  let version = snapshot.version();
+  let events = event_store
+    .get_events_by_id_since_seq_nr(id, snapshot_seq_nr + 1)
+    .await?;
+  let seq_nr = events.last().map(|event| event.seq_nr()).unwrap_or(snapshot_seq_nr);
+  let state = UserAccount::replay(
+    events.into_iter().map(EventEnvelope::into_payload),
+    snapshot.into_aggregate(),
+  );
+  Ok(Some(ReplayedUserAccount { state, seq_nr, version }))
 }
 
+/// 楽観ロックメッセージが許可キー（aid / expected_version / actual_version）のみで
+/// 構成されていることを検証する（NFR3.2 — エラー契約の書式固定）。
+pub fn assert_optimistic_lock_message_format(message: &str) {
+  let mut parts = message.split(", ");
+  assert_eq!(parts.next(), Some("optimistic lock failed"));
+  let allowed_keys = ["aid", "expected_version", "actual_version"];
+  for part in parts {
+    let key = part.split('=').next().unwrap();
+    assert!(allowed_keys.contains(&key), "unexpected field in message: {}", part);
+  }
+  assert!(!message.contains("://"), "message must not contain connection strings");
+}
+
+/// 共有シナリオ（v3 — 8 手順の assert 系列）。
+///
+/// C3: 全バックエンドが無改変で green にすべき受入契約。封筒メタデータ
+/// （manifest / occurred_at / aggregate_id / seq_nr）の往復 assert を含む。
 pub async fn exercise_user_account_flow<T>(
   event_store: &mut T,
   id: &UserAccountId,
 ) -> Result<(), Box<dyn StdError + Send + Sync>>
 where
-  T: EventStore<AID = UserAccountId, AG = UserAccount, EV = UserAccountEvent>, {
-  let (user_account, event) = UserAccount::new(id.clone(), "test".to_string());
-  event_store.persist_event_and_snapshot(&event, &user_account).await?;
+  T: EventStore<AID = UserAccountId, A = UserAccount, P = UserAccountEvent>, {
+  // 手順 1 — 作成: seq_nr=1 封筒（manifest 指定あり）+ 初期集約を expected_version=0 で永続化
+  let (user_account, created) = UserAccount::new(id.clone(), "test".to_string());
+  let occurred_at_1 = Utc::now();
+  let envelope_1 = EventEnvelope::new(id.clone(), 1, occurred_at_1, created).with_manifest(CREATED_MANIFEST);
+  event_store
+    .persist_event_and_snapshot(envelope_1, user_account.clone(), 0)
+    .await?;
 
-  let mut user_account = find_by_id(event_store, id).await?.unwrap();
-  assert_eq!(user_account.name, "test");
-  assert_eq!(user_account.seq_nr, 1);
-  assert_eq!(user_account.version, 1);
+  // 手順 2 — 読取 1: snapshot 封筒の version() == 1 / seq_nr() == 1、aggregate が初期状態と一致
+  let snapshot = event_store
+    .get_latest_snapshot_by_id(id)
+    .await?
+    .expect("snapshot must exist after creation");
+  assert_eq!(snapshot.version(), 1);
+  assert_eq!(snapshot.seq_nr(), 1);
+  assert_eq!(snapshot.aggregate(), &user_account);
 
-  let event = user_account.rename("test2").unwrap();
-  event_store.persist_event(&event, user_account.version()).await?;
+  // 手順 3 — 更新（リネーム）: seq_nr=2 封筒を expected_version=1 で永続化（スナップショット付き）
+  let mut state = snapshot.into_aggregate();
+  let renamed = state.rename("test2").unwrap();
+  let occurred_at_2 = Utc::now();
+  let envelope_2 = EventEnvelope::new(id.clone(), 2, occurred_at_2, renamed).with_manifest(RENAMED_MANIFEST);
+  event_store
+    .persist_event_and_snapshot(envelope_2, state.clone(), 1)
+    .await?;
 
-  let mut user_account = find_by_id(event_store, id).await?.unwrap();
-  assert_eq!(user_account.name, "test2");
-  assert_eq!(user_account.seq_nr, 2);
-  assert_eq!(user_account.version, 2);
+  // 手順 4 — 競合: 同じ expected_version=1 で再度永続化 → OptimisticLockError（書式は許可キーのみ）
+  let mut conflicting_state = state.clone();
+  let conflicting = conflicting_state.rename("conflict").unwrap();
+  let conflict_envelope = EventEnvelope::new(id.clone(), 2, Utc::now(), conflicting).with_manifest(RENAMED_MANIFEST);
+  let conflict_result = event_store
+    .persist_event_and_snapshot(conflict_envelope, conflicting_state, 1)
+    .await;
+  match conflict_result {
+    Err(EventStoreWriteError::OptimisticLockError(message)) => {
+      assert!(
+        message.starts_with(&format!("optimistic lock failed, aid={}, expected_version=1", id)),
+        "unexpected message: {}",
+        message
+      );
+      assert_optimistic_lock_message_format(&message);
+    }
+    other => panic!("expected OptimisticLockError, got {:?}", other),
+  }
 
-  let event = user_account.rename("test3").unwrap();
-  event_store.persist_event_and_snapshot(&event, &user_account).await?;
+  // 手順 5 — 読取 2: snapshot 封筒の version() == 2 / seq_nr() == 2
+  let snapshot = event_store
+    .get_latest_snapshot_by_id(id)
+    .await?
+    .expect("snapshot must exist after update");
+  assert_eq!(snapshot.version(), 2);
+  assert_eq!(snapshot.seq_nr(), 2);
+  assert_eq!(snapshot.aggregate(), &state);
 
-  let user_account = find_by_id(event_store, id).await?.unwrap();
-  assert_eq!(user_account.name, "test3");
-  assert_eq!(user_account.seq_nr, 3);
-  assert_eq!(user_account.version, 3);
+  // 手順 6 — イベントのみ更新（リネーム 2 回目）: seq_nr=3 を expected_version=2 で persist_event
+  let mut state = snapshot.into_aggregate();
+  let renamed_again = state.rename("test3").unwrap();
+  let occurred_at_3 = Utc::now();
+  // manifest 省略（既定の空文字列が往復することの検証を兼ねる — FR1.2）
+  let envelope_3 = EventEnvelope::new(id.clone(), 3, occurred_at_3, renamed_again);
+  event_store.persist_event(envelope_3, 2).await?;
+
+  // 手順 7 — ストリーム読取: 封筒 3 件が seq_nr 昇順で返り、各封筒のメタデータが書込時と同値
+  // （封筒メタデータ往復 assert — C3 の充足条件）
+  let events = event_store.get_events_by_id_since_seq_nr(id, 1).await?;
+  assert_eq!(events.len(), 3);
+
+  assert_eq!(events[0].aggregate_id(), id);
+  assert_eq!(events[0].seq_nr(), 1);
+  assert_eq!(events[0].occurred_at(), &occurred_at_1);
+  assert_eq!(events[0].manifest(), CREATED_MANIFEST);
+  assert_eq!(
+    events[0].payload(),
+    &UserAccountEvent::Created {
+      name: "test".to_string()
+    }
+  );
+
+  assert_eq!(events[1].aggregate_id(), id);
+  assert_eq!(events[1].seq_nr(), 2);
+  assert_eq!(events[1].occurred_at(), &occurred_at_2);
+  assert_eq!(events[1].manifest(), RENAMED_MANIFEST);
+  assert_eq!(
+    events[1].payload(),
+    &UserAccountEvent::Renamed {
+      name: "test2".to_string()
+    }
+  );
+
+  assert_eq!(events[2].aggregate_id(), id);
+  assert_eq!(events[2].seq_nr(), 3);
+  assert_eq!(events[2].occurred_at(), &occurred_at_3);
+  assert_eq!(events[2].manifest(), "");
+  assert_eq!(
+    events[2].payload(),
+    &UserAccountEvent::Renamed {
+      name: "test3".to_string()
+    }
+  );
+
+  // 手順 8 — リプレイ: snapshot（seq_nr=2）以降のイベント（seq_nr=3）を適用した結果が最新状態と一致
+  let snapshot = event_store
+    .get_latest_snapshot_by_id(id)
+    .await?
+    .expect("snapshot must exist after event-only update");
+  assert_eq!(snapshot.version(), 3);
+  assert_eq!(snapshot.seq_nr(), 2);
+  let replay_events = event_store
+    .get_events_by_id_since_seq_nr(id, snapshot.seq_nr() + 1)
+    .await?;
+  assert_eq!(replay_events.len(), 1);
+  assert_eq!(replay_events[0].seq_nr(), 3);
+  let replayed = UserAccount::replay(
+    replay_events.into_iter().map(EventEnvelope::into_payload),
+    snapshot.into_aggregate(),
+  );
+  assert_eq!(replayed, state);
+  assert_eq!(replayed.name, "test3");
 
   Ok(())
 }

--- a/lib/src/generic_event_store.rs
+++ b/lib/src/generic_event_store.rs
@@ -1,30 +1,52 @@
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use async_trait::async_trait;
 use chrono::Duration;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
 use crate::event_store_backend::{SnapshotMaintenance, StorageBackend};
-use crate::types::{Aggregate, AggregateId, Event, EventStore, EventStoreReadError, EventStoreWriteError};
+use crate::types::{AggregateId, EventStore, EventStoreReadError, EventStoreWriteError};
 
-#[derive(Debug, Clone)]
-pub struct GenericEventStore<AID, A, E, B>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-  B: StorageBackend<AID, A, E>, {
+// FR4.1: StorageBackend + GenericEventStore の 2 層委譲構造を維持したまま、境界の
+// 受け渡しを封筒（EventEnvelope / SnapshotEnvelope）に変更する。契約検証
+// （BR1.4 / BR2.2 / BR2.6 / BR4.1）と create/update 分岐（BR2.1）はこの層が持つ。
+
+// fnポインタ経由の型マーカー — Send/Sync自動導出を阻害しない
+type TypeMarker<AID, A, P> = fn() -> (AID, A, P);
+
+/// StorageBackend への委譲で `EventStore` を提供する汎用イベントストア。
+pub struct GenericEventStore<AID, A, P, B> {
   backend: B,
   maintenance: SnapshotMaintenance,
-  _phantom: PhantomData<(AID, A, E)>,
+  _phantom: PhantomData<TypeMarker<AID, A, P>>,
 }
 
-impl<AID, A, E, B> GenericEventStore<AID, A, E, B>
-where
-  AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-  B: StorageBackend<AID, A, E>,
-{
+// P2 / NFR2: derive は PhantomData の型パラメータ（AID / A / P）にも境界を課すため、
+// Debug / Clone は実フィールドが要求する境界（B のみ）に限定した手動 impl とする
+// （payload への Debug / Clone 要求を構造的に遮断する — BR1.6）
+impl<AID, A, P, B: Debug> Debug for GenericEventStore<AID, A, P, B> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("GenericEventStore")
+      .field("backend", &self.backend)
+      .field("maintenance", &self.maintenance)
+      .finish()
+  }
+}
+
+impl<AID, A, P, B: Clone> Clone for GenericEventStore<AID, A, P, B> {
+  fn clone(&self) -> Self {
+    Self {
+      backend: self.backend.clone(),
+      maintenance: self.maintenance.clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+impl<AID, A, P, B> GenericEventStore<AID, A, P, B> {
   pub fn new(backend: B) -> Self {
     Self {
       backend,
@@ -33,9 +55,19 @@ where
     }
   }
 
-  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Self {
+  /// 保持するスナップショット履歴数を設定する。
+  ///
+  /// BR4.1 / FR6.4 / P3: 有効値は `None`（剪定しない）と `Some(n >= 1)`（履歴 n 件保持）のみ。
+  /// `Some(0)` は `EventStoreWriteError::ContractViolation` で拒否する（検証はこの 1 箇所で行い、
+  /// 各ストア型のラッパーは Result を素通しする）。
+  pub fn with_keep_snapshot_count(mut self, keep_snapshot_count: Option<usize>) -> Result<Self, EventStoreWriteError> {
+    if keep_snapshot_count == Some(0) {
+      return Err(EventStoreWriteError::ContractViolation(
+        "BR4.1: keep_snapshot_count must be None or at least 1, keep_snapshot_count=0".to_string(),
+      ));
+    }
     self.maintenance.keep_snapshot_count = keep_snapshot_count;
-    self
+    Ok(self)
   }
 
   pub fn with_delete_ttl(mut self, delete_ttl: Option<Duration>) -> Self {
@@ -59,27 +91,46 @@ where
   }
 }
 
+// BR1.4: seq_nr は 1 以上。0 の封筒は書込時に契約エラーで拒否する
+fn validate_seq_nr_is_positive(seq_nr: usize) -> Result<(), EventStoreWriteError> {
+  if seq_nr == 0 {
+    return Err(EventStoreWriteError::ContractViolation(format!(
+      "BR1.4: seq_nr must be at least 1, seq_nr={}",
+      seq_nr
+    )));
+  }
+  Ok(())
+}
+
 #[async_trait]
-impl<AID, A, E, B> EventStore for GenericEventStore<AID, A, E, B>
+impl<AID, A, P, B> EventStore for GenericEventStore<AID, A, P, B>
 where
   AID: AggregateId,
-  A: Aggregate<ID = AID>,
-  E: Event<AggregateID = AID>,
-  B: StorageBackend<AID, A, E>,
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
+  B: StorageBackend<AID, A, P>,
 {
-  type AG = A;
+  type A = A;
   type AID = AID;
-  type EV = E;
+  type P = P;
 
-  async fn persist_event(&mut self, event: &Self::EV, version: usize) -> Result<(), EventStoreWriteError> {
-    if event.is_created() {
-      return Err(EventStoreWriteError::OtherError(
-        "persist_event cannot accept creation events".to_string(),
-      ));
+  async fn persist_event(
+    &mut self,
+    event: EventEnvelope<Self::AID, Self::P>,
+    expected_version: usize,
+  ) -> Result<(), EventStoreWriteError> {
+    validate_seq_nr_is_positive(event.seq_nr())?;
+    // BR2.2: イベントのみ API への seq_nr == 1（新規作成）は契約エラーで拒否する
+    if event.seq_nr() == 1 {
+      return Err(EventStoreWriteError::ContractViolation(format!(
+        "BR2.2: persist_event is update-only and cannot accept a creation event, seq_nr={}",
+        event.seq_nr()
+      )));
     }
+    // W2: イベントのみ更新 — version 加算は列側で行う（BR2.3）
     self
       .backend
-      .update_event_and_snapshot(event, None, version, &self.maintenance)
+      .update_event_and_snapshot(&event, None, expected_version, &self.maintenance)
       .await?;
     self
       .backend
@@ -89,18 +140,32 @@ where
 
   async fn persist_event_and_snapshot(
     &mut self,
-    event: &Self::EV,
-    aggregate: &Self::AG,
+    event: EventEnvelope<Self::AID, Self::P>,
+    aggregate: Self::A,
+    expected_version: usize,
   ) -> Result<(), EventStoreWriteError> {
-    if event.is_created() {
+    validate_seq_nr_is_positive(event.seq_nr())?;
+    // BR2.6: seq_nr == 1 ⇔ expected_version == 0 の対応が崩れる呼び出しを拒否する
+    if (event.seq_nr() == 1 && expected_version != 0) || (event.seq_nr() > 1 && expected_version == 0) {
+      return Err(EventStoreWriteError::ContractViolation(format!(
+        "BR2.6: seq_nr and expected_version are inconsistent (seq_nr == 1 <=> expected_version == 0), seq_nr={}, \
+         expected_version={}",
+        event.seq_nr(),
+        expected_version
+      )));
+    }
+    // BR2.1: create / update の分岐は封筒の seq_nr == 1 の導出で行う（is_created は存在しない）
+    if event.seq_nr() == 1 {
+      // W1: 新規作成 — journal + snapshot（version = 1、seq_nr = event.seq_nr）を原子的に作成
       self
         .backend
-        .create_event_and_snapshot(event, aggregate, &self.maintenance)
+        .create_event_and_snapshot(&event, &aggregate, &self.maintenance)
         .await?;
     } else {
+      // W3: 更新（スナップショット付き）— version CAS（BR2.3）
       self
         .backend
-        .update_event_and_snapshot(event, Some(aggregate), aggregate.version(), &self.maintenance)
+        .update_event_and_snapshot(&event, Some(&aggregate), expected_version, &self.maintenance)
         .await?;
     }
     self
@@ -109,21 +174,20 @@ where
       .await
   }
 
-  async fn get_latest_snapshot_by_id(&self, aid: &Self::AID) -> Result<Option<Self::AG>, EventStoreReadError> {
-    Ok(
-      self
-        .backend
-        .fetch_latest_snapshot(aid)
-        .await?
-        .map(|snapshot| snapshot.aggregate),
-    )
+  async fn get_latest_snapshot_by_id(
+    &self,
+    aid: &Self::AID,
+  ) -> Result<Option<SnapshotEnvelope<Self::A>>, EventStoreReadError> {
+    // FR2.2 / BR3.1: スナップショット封筒を透過返却し、seq_nr / version を境界で破棄しない
+    self.backend.fetch_latest_snapshot(aid).await
   }
 
   async fn get_events_by_id_since_seq_nr(
     &self,
     aid: &Self::AID,
     seq_nr: usize,
-  ) -> Result<Vec<Self::EV>, EventStoreReadError> {
+  ) -> Result<Vec<EventEnvelope<Self::AID, Self::P>>, EventStoreReadError> {
+    // FR5.1 / BR3.2: 封筒列を透過返却する
     self.backend.fetch_events_since(aid, seq_nr).await
   }
 }
@@ -131,9 +195,8 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::event_store_backend::SnapshotEnvelope;
   use async_trait::async_trait;
-  use chrono::{Duration as ChronoDuration, Utc};
+  use chrono::{DateTime, TimeZone, Utc};
   use serde::{Deserialize, Serialize};
   use std::fmt;
   use std::sync::{Arc, Mutex};
@@ -159,99 +222,28 @@ mod tests {
 
   #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
   struct TestAggregate {
-    id: TestAggregateId,
-    seq_nr: usize,
-    version: usize,
-    last_updated_at: chrono::DateTime<Utc>,
-  }
-
-  impl TestAggregate {
-    fn new(id: u64) -> (Self, TestEvent) {
-      let aggregate = TestAggregate {
-        id: TestAggregateId(id),
-        seq_nr: 1,
-        version: 1,
-        last_updated_at: Utc::now(),
-      };
-      let event = TestEvent::new(id, 1, true);
-      (aggregate, event)
-    }
-  }
-
-  impl Aggregate for TestAggregate {
-    type ID = TestAggregateId;
-
-    fn id(&self) -> &Self::ID {
-      &self.id
-    }
-
-    fn seq_nr(&self) -> usize {
-      self.seq_nr
-    }
-
-    fn version(&self) -> usize {
-      self.version
-    }
-
-    fn set_version(&mut self, version: usize) {
-      self.version = version;
-    }
-
-    fn last_updated_at(&self) -> &chrono::DateTime<Utc> {
-      &self.last_updated_at
-    }
+    name: String,
   }
 
   #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-  struct TestEvent {
-    id: u64,
-    aggregate_id: TestAggregateId,
-    seq_nr: usize,
-    occurred_at: chrono::DateTime<Utc>,
-    is_created: bool,
+  struct TestPayload {
+    name: String,
   }
 
-  impl TestEvent {
-    fn new(id: u64, seq_nr: usize, is_created: bool) -> Self {
-      Self {
-        id,
-        aggregate_id: TestAggregateId(id),
-        seq_nr,
-        occurred_at: Utc::now(),
-        is_created,
-      }
-    }
-
-    fn rename(id: u64, seq_nr: usize) -> Self {
-      Self::new(id, seq_nr, false)
-    }
+  fn fixed_occurred_at() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 8, 27, 0, 0, 0).unwrap()
   }
 
-  impl Event for TestEvent {
-    type AggregateID = TestAggregateId;
-    type ID = u64;
-
-    fn id(&self) -> &Self::ID {
-      &self.id
-    }
-
-    fn aggregate_id(&self) -> &Self::AggregateID {
-      &self.aggregate_id
-    }
-
-    fn seq_nr(&self) -> usize {
-      self.seq_nr
-    }
-
-    fn occurred_at(&self) -> &chrono::DateTime<Utc> {
-      &self.occurred_at
-    }
-
-    fn is_created(&self) -> bool {
-      self.is_created
-    }
+  fn envelope(id: u64, seq_nr: usize, name: &str) -> EventEnvelope<TestAggregateId, TestPayload> {
+    EventEnvelope::new(
+      TestAggregateId(id),
+      seq_nr,
+      fixed_occurred_at(),
+      TestPayload { name: name.to_string() },
+    )
   }
 
+  // 呼び出し記録 + 決め打ち応答のスタブ StorageBackend（外部モックライブラリは導入しない）
   #[derive(Clone)]
   struct TestBackend {
     state: Arc<Mutex<TestBackendState>>,
@@ -260,15 +252,14 @@ mod tests {
   #[derive(Default)]
   struct TestBackendState {
     snapshot: Option<SnapshotEnvelope<TestAggregate>>,
-    events: Vec<TestEvent>,
+    events: Vec<EventEnvelope<TestAggregateId, TestPayload>>,
     last_maintenance: Option<SnapshotMaintenance>,
     calls: Vec<String>,
   }
 
-  #[derive(Clone, Debug, PartialEq)]
-  struct TestBackendSnapshot {
+  struct TestBackendView {
     snapshot: Option<SnapshotEnvelope<TestAggregate>>,
-    events: Vec<TestEvent>,
+    events: Vec<EventEnvelope<TestAggregateId, TestPayload>>,
     last_maintenance: Option<SnapshotMaintenance>,
     calls: Vec<String>,
   }
@@ -286,9 +277,9 @@ mod tests {
       }
     }
 
-    fn snapshot_state(&self) -> TestBackendSnapshot {
+    fn view(&self) -> TestBackendView {
       let state = self.state.lock().unwrap();
-      TestBackendSnapshot {
+      TestBackendView {
         snapshot: state.snapshot.clone(),
         events: state.events.clone(),
         last_maintenance: state.last_maintenance.clone(),
@@ -298,7 +289,7 @@ mod tests {
   }
 
   #[async_trait]
-  impl StorageBackend<TestAggregateId, TestAggregate, TestEvent> for TestBackend {
+  impl StorageBackend<TestAggregateId, TestAggregate, TestPayload> for TestBackend {
     async fn fetch_latest_snapshot(
       &self,
       _aid: &TestAggregateId,
@@ -311,7 +302,7 @@ mod tests {
       &self,
       _aid: &TestAggregateId,
       seq_nr: usize,
-    ) -> Result<Vec<TestEvent>, EventStoreReadError> {
+    ) -> Result<Vec<EventEnvelope<TestAggregateId, TestPayload>>, EventStoreReadError> {
       let state = self.state.lock().unwrap();
       Ok(
         state
@@ -325,42 +316,40 @@ mod tests {
 
     async fn create_event_and_snapshot(
       &self,
-      event: &TestEvent,
+      event: &EventEnvelope<TestAggregateId, TestPayload>,
       aggregate: &TestAggregate,
       _maintenance: &SnapshotMaintenance,
     ) -> Result<(), EventStoreWriteError> {
       let mut state = self.state.lock().unwrap();
       state.calls.push("create".to_string());
-      state.snapshot = Some(SnapshotEnvelope {
-        aggregate: aggregate.clone(),
-        seq_nr: aggregate.seq_nr(),
-        version: aggregate.version(),
-      });
+      state.snapshot = Some(SnapshotEnvelope::new(aggregate.clone(), event.seq_nr(), 1));
       state.events.push(event.clone());
       Ok(())
     }
 
     async fn update_event_and_snapshot(
       &self,
-      event: &TestEvent,
+      event: &EventEnvelope<TestAggregateId, TestPayload>,
       aggregate: Option<&TestAggregate>,
       expected_version: usize,
       _maintenance: &SnapshotMaintenance,
     ) -> Result<(), EventStoreWriteError> {
       let mut state = self.state.lock().unwrap();
-      state.calls.push("update".to_string());
-      let snapshot = state
+      state
+        .calls
+        .push(format!("update(expected_version={})", expected_version));
+      let current = state
         .snapshot
-        .as_mut()
+        .as_ref()
         .ok_or_else(|| EventStoreWriteError::OtherError("snapshot not found".to_string()))?;
-      if snapshot.version != expected_version {
+      if current.version() != expected_version {
         return Err(EventStoreWriteError::OtherError("version mismatch".to_string()));
       }
-      snapshot.version += 1;
-      snapshot.seq_nr = event.seq_nr();
-      if let Some(aggregate) = aggregate {
-        snapshot.aggregate = aggregate.clone();
-      }
+      let new_version = expected_version + 1;
+      state.snapshot = Some(match aggregate {
+        Some(aggregate) => SnapshotEnvelope::new(aggregate.clone(), event.seq_nr(), new_version),
+        None => SnapshotEnvelope::new(current.aggregate().clone(), current.seq_nr(), new_version),
+      });
       state.events.push(event.clone());
       Ok(())
     }
@@ -377,94 +366,410 @@ mod tests {
     }
   }
 
-  #[tokio::test]
-  async fn persist_creation_stores_snapshot_and_event() {
+  fn new_store() -> (
+    TestBackend,
+    GenericEventStore<TestAggregateId, TestAggregate, TestPayload, TestBackend>,
+  ) {
     let backend = TestBackend::new();
-    let mut store = GenericEventStore::new(backend.clone());
-    let (aggregate, event) = TestAggregate::new(1);
+    let store = GenericEventStore::new(backend.clone());
+    (backend, store)
+  }
+
+  // W1 / BR2.1 / AC2.3.1: seq_nr == 1 + expected_version == 0 は新規作成経路へ委譲される
+  #[tokio::test]
+  async fn test_persist_event_and_snapshot_with_seq_nr_one_delegates_to_create() {
+    let (backend, mut store) = new_store();
 
     store
-      .persist_event_and_snapshot(&event, &aggregate)
+      .persist_event_and_snapshot(
+        envelope(1, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
       .await
       .expect("creation should succeed");
 
-    let state = backend.snapshot_state();
-    assert_eq!(state.calls, vec!["create", "on_event"]);
-    assert_eq!(state.events.len(), 1);
-    let snapshot = state.snapshot.expect("snapshot stored");
-    assert_eq!(snapshot.version, 1);
-    assert_eq!(snapshot.seq_nr, 1);
-    assert_eq!(snapshot.aggregate, aggregate);
+    let view = backend.view();
+    assert_eq!(view.calls, vec!["create", "on_event"]);
+    assert_eq!(view.events.len(), 1);
+    let snapshot = view.snapshot.expect("snapshot stored");
+    assert_eq!(snapshot.version(), 1);
+    assert_eq!(snapshot.seq_nr(), 1);
+    assert_eq!(snapshot.aggregate().name, "test");
   }
 
+  // W3 / AC2.3.2: seq_nr > 1 は更新経路（aggregate 付き）へ委譲され expected_version が透過する
   #[tokio::test]
-  async fn persist_event_updates_snapshot_version() {
-    let backend = TestBackend::new();
-    let mut store = GenericEventStore::new(backend.clone());
-    let (aggregate, event) = TestAggregate::new(1);
-    store.persist_event_and_snapshot(&event, &aggregate).await.unwrap();
+  async fn test_persist_event_and_snapshot_with_seq_nr_above_one_delegates_to_update() {
+    let (backend, mut store) = new_store();
+    store
+      .persist_event_and_snapshot(
+        envelope(1, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
+      .await
+      .unwrap();
 
-    let update_event = TestEvent::rename(1, 2);
-    store.persist_event(&update_event, 1).await.unwrap();
+    store
+      .persist_event_and_snapshot(
+        envelope(1, 2, "renamed"),
+        TestAggregate {
+          name: "test2".to_string(),
+        },
+        1,
+      )
+      .await
+      .expect("update should succeed");
 
-    let state = backend.snapshot_state();
-    assert_eq!(state.calls, vec!["create", "on_event", "update", "on_event"]);
-    let snapshot = state.snapshot.expect("snapshot stored");
-    assert_eq!(snapshot.version, 2);
-    assert_eq!(snapshot.seq_nr, 2);
-    assert_eq!(state.events.len(), 2);
+    let view = backend.view();
+    assert_eq!(
+      view.calls,
+      vec!["create", "on_event", "update(expected_version=1)", "on_event"]
+    );
+    let snapshot = view.snapshot.expect("snapshot stored");
+    assert_eq!(snapshot.version(), 2);
+    assert_eq!(snapshot.seq_nr(), 2);
+    assert_eq!(snapshot.aggregate().name, "test2");
+    assert_eq!(view.events.len(), 2);
   }
 
+  // W2 / AC2.1.4 の対偶経路: persist_event は aggregate なしの更新へ委譲される
   #[tokio::test]
-  async fn persist_event_rejects_creation_event() {
-    let backend = TestBackend::new();
-    let mut store = GenericEventStore::new(backend.clone());
-    let creation_event = TestEvent::new(1, 1, true);
-    let result = store.persist_event(&creation_event, 0).await;
-    assert!(result.is_err());
+  async fn test_persist_event_delegates_to_update_without_aggregate() {
+    let (backend, mut store) = new_store();
+    store
+      .persist_event_and_snapshot(
+        envelope(1, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
+      .await
+      .unwrap();
+
+    store
+      .persist_event(envelope(1, 2, "renamed"), 1)
+      .await
+      .expect("event-only update should succeed");
+
+    let view = backend.view();
+    assert_eq!(
+      view.calls,
+      vec!["create", "on_event", "update(expected_version=1)", "on_event"]
+    );
+    let snapshot = view.snapshot.expect("snapshot stored");
+    // イベントのみ更新では version のみ加算され、スナップショットの aggregate / seq_nr は据え置き
+    assert_eq!(snapshot.version(), 2);
+    assert_eq!(snapshot.seq_nr(), 1);
+    assert_eq!(snapshot.aggregate().name, "test");
+    assert_eq!(view.events.len(), 2);
   }
 
+  // BR1.4: seq_nr == 0 の封筒は persist_event で ContractViolation（バックエンド不達）
   #[tokio::test]
-  async fn maintenance_configuration_is_passed_to_backend() {
+  async fn test_persist_event_rejects_seq_nr_zero() {
+    let (backend, mut store) = new_store();
+    let result = store.persist_event(envelope(1, 0, "zero"), 1).await;
+    match result {
+      Err(EventStoreWriteError::ContractViolation(reason)) => {
+        assert_eq!(reason, "BR1.4: seq_nr must be at least 1, seq_nr=0");
+      }
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    assert!(backend.view().calls.is_empty(), "backend must not be reached");
+  }
+
+  // BR1.4: seq_nr == 0 の封筒は persist_event_and_snapshot でも ContractViolation
+  #[tokio::test]
+  async fn test_persist_event_and_snapshot_rejects_seq_nr_zero() {
+    let (backend, mut store) = new_store();
+    let result = store
+      .persist_event_and_snapshot(
+        envelope(1, 0, "zero"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
+      .await;
+    match result {
+      Err(EventStoreWriteError::ContractViolation(reason)) => {
+        assert_eq!(reason, "BR1.4: seq_nr must be at least 1, seq_nr=0");
+      }
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    assert!(backend.view().calls.is_empty(), "backend must not be reached");
+  }
+
+  // BR2.2 / AC2.1.4: イベントのみ API への seq_nr == 1（新規作成）は ContractViolation
+  #[tokio::test]
+  async fn test_persist_event_rejects_creation_seq_nr() {
+    let (backend, mut store) = new_store();
+    let result = store.persist_event(envelope(1, 1, "created"), 0).await;
+    match result {
+      Err(EventStoreWriteError::ContractViolation(reason)) => {
+        assert_eq!(
+          reason,
+          "BR2.2: persist_event is update-only and cannot accept a creation event, seq_nr=1"
+        );
+      }
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    assert!(backend.view().calls.is_empty(), "backend must not be reached");
+  }
+
+  // BR2.6: seq_nr == 1 かつ expected_version != 0 は ContractViolation
+  #[tokio::test]
+  async fn test_persist_event_and_snapshot_rejects_creation_with_nonzero_expected_version() {
+    let (backend, mut store) = new_store();
+    let result = store
+      .persist_event_and_snapshot(
+        envelope(1, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        5,
+      )
+      .await;
+    match result {
+      Err(EventStoreWriteError::ContractViolation(reason)) => {
+        assert_eq!(
+          reason,
+          "BR2.6: seq_nr and expected_version are inconsistent (seq_nr == 1 <=> expected_version == 0), seq_nr=1, \
+           expected_version=5"
+        );
+      }
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    assert!(backend.view().calls.is_empty(), "backend must not be reached");
+  }
+
+  // BR2.6: seq_nr > 1 かつ expected_version == 0 は ContractViolation
+  #[tokio::test]
+  async fn test_persist_event_and_snapshot_rejects_update_with_zero_expected_version() {
+    let (backend, mut store) = new_store();
+    let result = store
+      .persist_event_and_snapshot(
+        envelope(1, 2, "renamed"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
+      .await;
+    match result {
+      Err(EventStoreWriteError::ContractViolation(reason)) => {
+        assert_eq!(
+          reason,
+          "BR2.6: seq_nr and expected_version are inconsistent (seq_nr == 1 <=> expected_version == 0), seq_nr=2, \
+           expected_version=0"
+        );
+      }
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    assert!(backend.view().calls.is_empty(), "backend must not be reached");
+  }
+
+  // BR4.1 / W5: with_keep_snapshot_count は Some(0) を拒否し、None / Some(n >= 1) を受理する
+  #[tokio::test]
+  async fn test_with_keep_snapshot_count_rejects_zero() {
+    let (_backend, store) = new_store();
+    let result = store.with_keep_snapshot_count(Some(0));
+    match result {
+      Err(EventStoreWriteError::ContractViolation(reason)) => {
+        assert_eq!(
+          reason,
+          "BR4.1: keep_snapshot_count must be None or at least 1, keep_snapshot_count=0"
+        );
+      }
+      other => panic!("expected ContractViolation, got {:?}", other.map(|_| ())),
+    }
+
+    let (_backend, store) = new_store();
+    let store = store.with_keep_snapshot_count(Some(1)).expect("Some(1) is valid");
+    let store = store.with_keep_snapshot_count(None).expect("None is valid");
+    assert_eq!(store.maintenance().keep_snapshot_count, None);
+  }
+
+  // BR4.2 経路の設定運搬: maintenance 設定がバックエンドの書込後フックまで透過する
+  #[tokio::test]
+  async fn test_maintenance_configuration_is_passed_to_backend() {
     let backend = TestBackend::new();
     let mut store = GenericEventStore::new(backend.clone())
       .with_keep_snapshot_count(Some(2))
-      .with_delete_ttl(Some(ChronoDuration::seconds(30)));
-    let (aggregate, event) = TestAggregate::new(42);
+      .unwrap()
+      .with_delete_ttl(Some(Duration::seconds(30)));
 
-    store.persist_event_and_snapshot(&event, &aggregate).await.unwrap();
+    store
+      .persist_event_and_snapshot(
+        envelope(42, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
+      .await
+      .unwrap();
 
-    let state = backend.snapshot_state();
+    let view = backend.view();
     assert_eq!(
-      state.last_maintenance,
+      view.last_maintenance,
       Some(SnapshotMaintenance {
         keep_snapshot_count: Some(2),
-        delete_ttl: Some(ChronoDuration::seconds(30)),
+        delete_ttl: Some(Duration::seconds(30)),
       })
     );
   }
 
+  // FR2.2 / BR3.1: スナップショット封筒が seq_nr / version を破棄されず透過返却される
   #[tokio::test]
-  async fn update_with_snapshot_replaces_aggregate_when_provided() {
-    let backend = TestBackend::new();
-    let mut store = GenericEventStore::new(backend.clone());
-    let (aggregate, event) = TestAggregate::new(7);
-    store.persist_event_and_snapshot(&event, &aggregate).await.unwrap();
-
-    let mut updated_aggregate = aggregate.clone();
-    updated_aggregate.seq_nr = 2;
-    updated_aggregate.version = 1;
-    let update_event = TestEvent::rename(7, 2);
+  async fn test_get_latest_snapshot_returns_envelope_transparently() {
+    let (_backend, mut store) = new_store();
     store
-      .persist_event_and_snapshot(&update_event, &updated_aggregate)
+      .persist_event_and_snapshot(
+        envelope(1, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
       .await
       .unwrap();
 
-    let state = backend.snapshot_state();
-    let snapshot = state.snapshot.expect("snapshot stored");
-    assert_eq!(snapshot.version, 2);
-    assert_eq!(snapshot.seq_nr, 2);
-    assert_eq!(snapshot.aggregate, updated_aggregate);
-    assert_eq!(state.events.len(), 2);
+    let snapshot = store
+      .get_latest_snapshot_by_id(&TestAggregateId(1))
+      .await
+      .unwrap()
+      .expect("snapshot must exist");
+    assert_eq!(snapshot.version(), 1);
+    assert_eq!(snapshot.seq_nr(), 1);
+    assert_eq!(snapshot.aggregate().name, "test");
+
+    // 不在は None（エラーにしない）
+    let (_backend2, store2) = new_store();
+    let missing = store2.get_latest_snapshot_by_id(&TestAggregateId(9)).await.unwrap();
+    assert!(missing.is_none());
+  }
+
+  // FR5.1 / BR3.2: イベント読取は封筒列を返し、列由来メタデータが取得できる
+  #[tokio::test]
+  async fn test_get_events_since_returns_envelopes() {
+    let (_backend, mut store) = new_store();
+    store
+      .persist_event_and_snapshot(
+        envelope(1, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
+      .await
+      .unwrap();
+    store.persist_event(envelope(1, 2, "renamed"), 1).await.unwrap();
+
+    let events = store
+      .get_events_by_id_since_seq_nr(&TestAggregateId(1), 2)
+      .await
+      .unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].seq_nr(), 2);
+    assert_eq!(events[0].aggregate_id(), &TestAggregateId(1));
+    assert_eq!(events[0].payload().name, "renamed");
+  }
+
+  // FR7.3 ② / NFR2: derive なしプレーン型（Debug / Clone なし）でも GenericEventStore が
+  // EventStore を実装できることのコンパイル証明（derive 戦略の回帰ガード）
+  #[derive(Serialize, Deserialize)]
+  struct PlainAggregate {
+    name: String,
+  }
+
+  #[derive(Serialize, Deserialize)]
+  struct PlainPayload {
+    name: String,
+  }
+
+  #[derive(Clone, Debug)]
+  struct PlainBackend;
+
+  #[async_trait]
+  impl StorageBackend<TestAggregateId, PlainAggregate, PlainPayload> for PlainBackend {
+    async fn fetch_latest_snapshot(
+      &self,
+      _aid: &TestAggregateId,
+    ) -> Result<Option<SnapshotEnvelope<PlainAggregate>>, EventStoreReadError> {
+      Ok(None)
+    }
+
+    async fn fetch_events_since(
+      &self,
+      _aid: &TestAggregateId,
+      _seq_nr: usize,
+    ) -> Result<Vec<EventEnvelope<TestAggregateId, PlainPayload>>, EventStoreReadError> {
+      Ok(Vec::new())
+    }
+
+    async fn create_event_and_snapshot(
+      &self,
+      _event: &EventEnvelope<TestAggregateId, PlainPayload>,
+      _aggregate: &PlainAggregate,
+      _maintenance: &SnapshotMaintenance,
+    ) -> Result<(), EventStoreWriteError> {
+      Ok(())
+    }
+
+    async fn update_event_and_snapshot(
+      &self,
+      _event: &EventEnvelope<TestAggregateId, PlainPayload>,
+      _aggregate: Option<&PlainAggregate>,
+      _expected_version: usize,
+      _maintenance: &SnapshotMaintenance,
+    ) -> Result<(), EventStoreWriteError> {
+      Ok(())
+    }
+  }
+
+  #[tokio::test]
+  async fn test_generic_event_store_implements_event_store_for_plain_types() {
+    // EventStore（Debug + Clone + Send + Sync + 'static を要求）の実装が
+    // Debug / Clone なしの A / P で成立することのコンパイル検証
+    fn assert_implements_event_store<T: EventStore>(_store: &T) {}
+
+    let mut store: GenericEventStore<TestAggregateId, PlainAggregate, PlainPayload, PlainBackend> =
+      GenericEventStore::new(PlainBackend);
+    assert_implements_event_store(&store);
+
+    let event = EventEnvelope::new(
+      TestAggregateId(1),
+      1,
+      fixed_occurred_at(),
+      PlainPayload {
+        name: "created".to_string(),
+      },
+    );
+    store
+      .persist_event_and_snapshot(
+        event,
+        PlainAggregate {
+          name: "test".to_string(),
+        },
+        0,
+      )
+      .await
+      .unwrap();
+
+    let snapshot = store.get_latest_snapshot_by_id(&TestAggregateId(1)).await.unwrap();
+    assert!(snapshot.is_none(), "canned backend returns no snapshot");
+    let events = store
+      .get_events_by_id_since_seq_nr(&TestAggregateId(1), 1)
+      .await
+      .unwrap();
+    assert!(events.is_empty(), "canned backend returns no events");
   }
 }

--- a/lib/src/generic_event_store.rs
+++ b/lib/src/generic_event_store.rs
@@ -687,6 +687,82 @@ mod tests {
     assert_eq!(events[0].payload().name, "renamed");
   }
 
+  // NFR3.2 / BR5.2 / P1: ContractViolation の理由文字列が「規約名 + seq_nr / expected_version の
+  // 数値」テンプレートのみで構成されること（それ以外の情報を含まないこと）を機械的に固定する
+  // （OptimisticLockError の許可キー検証と同格の回帰テスト）
+  fn assert_contract_violation_reason_template(reason: &str) {
+    let mut parts = reason.split(", ");
+    let head = parts.next().unwrap();
+    // 先頭は「BR<x>.<y>: <固定説明文>」— 規約名で始まる
+    let (rule_id, description) = head.split_once(": ").expect("reason must start with a rule id prefix");
+    assert!(
+      rule_id.starts_with("BR")
+        && rule_id[2..]
+          .split('.')
+          .all(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())),
+      "reason must start with a BR rule id, got: {}",
+      rule_id
+    );
+    assert!(!description.is_empty());
+    // 後続はすべて許可キーの key=数値 のみ（集約 ID・payload 内容・接続情報は含めない）
+    let allowed_keys = ["seq_nr", "expected_version", "keep_snapshot_count"];
+    for part in parts {
+      let (key, value) = part
+        .split_once('=')
+        .unwrap_or_else(|| panic!("non key=value part in reason: {}", part));
+      assert!(allowed_keys.contains(&key), "unexpected field in reason: {}", part);
+      assert!(
+        !value.is_empty() && value.bytes().all(|b| b.is_ascii_digit()),
+        "non-numeric value in reason: {}",
+        part
+      );
+    }
+    assert!(!reason.contains("://"), "reason must not contain connection strings");
+  }
+
+  #[tokio::test]
+  async fn test_contract_violation_reason_strings_follow_fixed_template() {
+    // ContractViolation を返す全 4 規則（BR1.4 / BR2.2 / BR2.6 / BR4.1）の理由文字列を収集する
+    let (_backend, mut store) = new_store();
+    let mut reasons = Vec::new();
+
+    // BR1.4
+    match store.persist_event(envelope(1, 0, "zero"), 1).await {
+      Err(EventStoreWriteError::ContractViolation(reason)) => reasons.push(reason),
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    // BR2.2
+    match store.persist_event(envelope(1, 1, "created"), 0).await {
+      Err(EventStoreWriteError::ContractViolation(reason)) => reasons.push(reason),
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    // BR2.6
+    match store
+      .persist_event_and_snapshot(
+        envelope(1, 1, "created"),
+        TestAggregate {
+          name: "test".to_string(),
+        },
+        5,
+      )
+      .await
+    {
+      Err(EventStoreWriteError::ContractViolation(reason)) => reasons.push(reason),
+      other => panic!("expected ContractViolation, got {:?}", other),
+    }
+    // BR4.1
+    let (_backend2, store2) = new_store();
+    match store2.with_keep_snapshot_count(Some(0)) {
+      Err(EventStoreWriteError::ContractViolation(reason)) => reasons.push(reason),
+      other => panic!("expected ContractViolation, got {:?}", other.map(|_| ())),
+    }
+
+    assert_eq!(reasons.len(), 4);
+    for reason in &reasons {
+      assert_contract_violation_reason_template(reason);
+    }
+  }
+
   // FR7.3 ② / NFR2: derive なしプレーン型（Debug / Clone なし）でも GenericEventStore が
   // EventStore を実装できることのコンパイル証明（derive 戦略の回帰ガード）
   #[derive(Serialize, Deserialize)]

--- a/lib/src/generic_event_store.rs
+++ b/lib/src/generic_event_store.rs
@@ -338,10 +338,14 @@ mod tests {
       state
         .calls
         .push(format!("update(expected_version={})", expected_version));
-      let current = state
-        .snapshot
-        .as_ref()
-        .ok_or_else(|| EventStoreWriteError::OtherError("snapshot not found".to_string()))?;
+      // BR2.3 / AC2.2.3: 対象集約が不在の更新は楽観ロック競合（actual_version なし書式）— 実体と同じ意味論
+      let current = state.snapshot.as_ref().ok_or_else(|| {
+        EventStoreWriteError::OptimisticLockError(crate::types::format_optimistic_lock_message(
+          &event.aggregate_id().to_string(),
+          expected_version,
+          None,
+        ))
+      })?;
       if current.version() != expected_version {
         return Err(EventStoreWriteError::OtherError("version mismatch".to_string()));
       }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod event_envelope;
+#[cfg(test)]
+mod event_envelope_test;
 mod event_store_backend;
 #[cfg(feature = "bigtable")]
 mod event_store_for_bigtable;

--- a/lib/src/serializer.rs
+++ b/lib/src/serializer.rs
@@ -1,62 +1,90 @@
-use crate::types::{Aggregate, Event, EventStoreReadError, EventStoreWriteError};
+use crate::types::{EventStoreReadError, EventStoreWriteError};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
-pub trait EventSerializer<E: Event>: Debug + Send + Sync + 'static {
-  fn serialize(&self, event: &E) -> Result<Vec<u8>, EventStoreWriteError>;
-  fn deserialize(&self, data: &[u8]) -> Result<Box<E>, EventStoreReadError>;
+// FR4.2 / BR2.4: シリアライザは payload（P / A の値）のみを直列化の対象とする。
+// 封筒メタデータ（aggregate_id / seq_nr / occurred_at / manifest / version）は列側が持ち、
+// この境界には現れない（メタデータ非複製の構造的保証）。
+
+// fnポインタ経由の型マーカー — Send/Sync自動導出を阻害しない
+type SerializerTypeMarker<T> = fn() -> T;
+
+/// イベント payload の直列化契約を表すトレイト。
+pub trait EventSerializer<P>: Debug + Send + Sync + 'static {
+  /// payload をバイト列へ直列化する。
+  fn serialize(&self, payload: &P) -> Result<Vec<u8>, EventStoreWriteError>;
+  /// バイト列から payload を復元する。
+  fn deserialize(&self, data: &[u8]) -> Result<P, EventStoreReadError>;
 }
 
-#[derive(Debug)]
-pub struct JsonEventSerializer<E: Event> {
-  _phantom: std::marker::PhantomData<E>,
+/// JSON 形式の既定イベント payload シリアライザ。
+pub struct JsonEventSerializer<P> {
+  _phantom: PhantomData<SerializerTypeMarker<P>>,
 }
 
-impl<E: Event> Default for JsonEventSerializer<E> {
+// P2: derive は PhantomData の型パラメータにも境界を課すため、Debug は手動 impl とし
+// payload への Debug 要求を作らない（BR1.6 の最小境界維持）
+impl<P> Debug for JsonEventSerializer<P> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("JsonEventSerializer").finish()
+  }
+}
+
+impl<P> Default for JsonEventSerializer<P> {
   fn default() -> Self {
-    JsonEventSerializer {
-      _phantom: std::marker::PhantomData,
-    }
+    JsonEventSerializer { _phantom: PhantomData }
   }
 }
 
-impl<E: Event> EventSerializer<E> for JsonEventSerializer<E> {
-  fn serialize(&self, event: &E) -> Result<Vec<u8>, EventStoreWriteError> {
-    serde_json::to_vec(event).map_err(|e| EventStoreWriteError::SerializationError(e.into()))
+impl<P> EventSerializer<P> for JsonEventSerializer<P>
+where
+  P: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+  fn serialize(&self, payload: &P) -> Result<Vec<u8>, EventStoreWriteError> {
+    serde_json::to_vec(payload).map_err(|e| EventStoreWriteError::SerializationError(e.into()))
   }
 
-  fn deserialize(&self, data: &[u8]) -> Result<Box<E>, EventStoreReadError> {
-    serde_json::from_slice(data)
-      .map_err(|e| EventStoreReadError::DeserializationError(e.into()))
-      .map(Box::new)
+  fn deserialize(&self, data: &[u8]) -> Result<P, EventStoreReadError> {
+    serde_json::from_slice(data).map_err(|e| EventStoreReadError::DeserializationError(e.into()))
   }
 }
 
-pub trait SnapshotSerializer<A: Aggregate>: Debug + Send + Sync + 'static {
+/// スナップショット（集約 payload）の直列化契約を表すトレイト。
+pub trait SnapshotSerializer<A>: Debug + Send + Sync + 'static {
+  /// 集約 payload をバイト列へ直列化する。
   fn serialize(&self, aggregate: &A) -> Result<Vec<u8>, EventStoreWriteError>;
-  fn deserialize(&self, data: &[u8]) -> Result<Box<A>, EventStoreReadError>;
+  /// バイト列から集約 payload を復元する。
+  fn deserialize(&self, data: &[u8]) -> Result<A, EventStoreReadError>;
 }
 
-#[derive(Debug)]
-pub struct JsonSnapshotSerializer<A: Aggregate> {
-  _phantom: std::marker::PhantomData<A>,
+/// JSON 形式の既定スナップショットシリアライザ。
+pub struct JsonSnapshotSerializer<A> {
+  _phantom: PhantomData<SerializerTypeMarker<A>>,
 }
 
-impl<A: Aggregate> Default for JsonSnapshotSerializer<A> {
-  fn default() -> Self {
-    JsonSnapshotSerializer {
-      _phantom: std::marker::PhantomData,
-    }
+impl<A> Debug for JsonSnapshotSerializer<A> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("JsonSnapshotSerializer").finish()
   }
 }
 
-impl<A: Aggregate> SnapshotSerializer<A> for JsonSnapshotSerializer<A> {
+impl<A> Default for JsonSnapshotSerializer<A> {
+  fn default() -> Self {
+    JsonSnapshotSerializer { _phantom: PhantomData }
+  }
+}
+
+impl<A> SnapshotSerializer<A> for JsonSnapshotSerializer<A>
+where
+  A: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
   fn serialize(&self, aggregate: &A) -> Result<Vec<u8>, EventStoreWriteError> {
     serde_json::to_vec(aggregate).map_err(|e| EventStoreWriteError::SerializationError(e.into()))
   }
 
-  fn deserialize(&self, data: &[u8]) -> Result<Box<A>, EventStoreReadError> {
-    serde_json::from_slice(data)
-      .map_err(|e| EventStoreReadError::DeserializationError(e.into()))
-      .map(Box::new)
+  fn deserialize(&self, data: &[u8]) -> Result<A, EventStoreReadError> {
+    serde_json::from_slice(data).map_err(|e| EventStoreReadError::DeserializationError(e.into()))
   }
 }

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -1,9 +1,15 @@
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
 use serde::{de, Serialize};
 use std::error::Error as StdError;
 use std::fmt::Debug;
 use thiserror::Error;
+
+use crate::event_envelope::{EventEnvelope, SnapshotEnvelope};
+
+// FR3.1 / FR3.2: v3 で `Event` / `Aggregate` trait は廃止した。ドメインイベント・集約状態は
+// ライブラリ trait を実装しないプレーンな serde 型（payload）として扱い、メタデータは
+// 封筒（EventEnvelope / SnapshotEnvelope）が運搬する。
 
 /// 集約のIDを表すトレイト。
 pub trait AggregateId:
@@ -14,78 +20,97 @@ pub trait AggregateId:
   fn value(&self) -> String;
 }
 
-/// イベントを表すトレイト。
-pub trait Event: Debug + Clone + Serialize + for<'de> de::Deserialize<'de> + Send + Sync + 'static {
-  type ID: std::fmt::Display;
-  type AggregateID: AggregateId;
-  fn id(&self) -> &Self::ID;
-  fn aggregate_id(&self) -> &Self::AggregateID;
-  fn seq_nr(&self) -> usize;
-  fn occurred_at(&self) -> &DateTime<Utc>;
-  fn is_created(&self) -> bool;
-}
-
-/// 集約を表すトレイト。
-pub trait Aggregate: Debug + Clone + Serialize + for<'de> de::Deserialize<'de> + Send + Sync + 'static {
-  type ID: AggregateId;
-  /// IDを返す。
-  fn id(&self) -> &Self::ID;
-  /// シーケンス番号を返す。
-  fn seq_nr(&self) -> usize;
-  /// バージョンを返す。
-  fn version(&self) -> usize;
-  /// シーケンス番号を設定する。
-  fn set_version(&mut self, version: usize);
-  /// 最終更新日時を返す。
-  fn last_updated_at(&self) -> &DateTime<Utc>;
-}
-
 /// イベントストアを表すトレイト。
+///
+/// イベント・集約状態は封筒（[`EventEnvelope`] / [`SnapshotEnvelope`]）で受け渡し、
+/// ストアは封筒を透過運搬してメタデータを破棄しない（FR2.2 / FR5.1 / FR5.2）。
+///
+/// # payload の型要求（FR3.1 / BR1.6）
+///
+/// 集約 payload（`A`）とイベント payload（`P`）への要求は最小境界
+/// `Serialize + DeserializeOwned + Send + Sync + 'static` のみで、`Debug` / `Clone` は
+/// 要求しない（Memory バックエンドの実装のみ追加で `Clone` を要求する — 文書化済みの非対称）。
+///
+/// # seq_nr 契約（FR3.3 / FR3.4 / BR6.1）
+///
+/// - seq_nr は 1 始まりで、同一ストリーム内で連続していることを利用者（ドメイン側）が保証する。
+///   採番はドメイン側の責務であり、ストアは採番しない
+/// - ライブラリは連続性を検証しない。重複した seq_nr は楽観ロック（CAS / 一意制約）が拒否し、
+///   飛び番は検出されずそのまま書き込まれる（利用者責務）
+/// - 最初のイベント（新規作成）は seq_nr == 1 であり、create / update の分岐はこの導出で行う（BR2.1）
+///
+/// # expected_version の規約（BR2.3 / BR2.6）
+///
+/// 新規作成（seq_nr == 1）は `expected_version == 0`、更新は読取済み
+/// [`SnapshotEnvelope::version`] の値を渡す。対応が崩れる呼び出しは
+/// [`EventStoreWriteError::ContractViolation`] で拒否される。
 #[async_trait]
 pub trait EventStore: Debug + Clone + Sync + Send + 'static {
-  /// イベントの型。
-  type EV: Event;
-  /// 集約の型。
-  type AG: Aggregate;
   /// 集約のIDの型。
   type AID: AggregateId;
+  /// 集約 payload の型（純ドメイン状態 — 最小境界のみ、BR1.6）。
+  type A: Serialize + DeserializeOwned + Send + Sync + 'static;
+  /// イベント payload の型（純ドメイン内容 — 最小境界のみ、BR1.6）。
+  type P: Serialize + DeserializeOwned + Send + Sync + 'static;
 
-  /// イベントを保存します。
+  /// イベント封筒のみを保存します（更新専用）。
+  ///
+  /// BR2.2: seq_nr == 1（新規作成）の封筒は受け付けず、
+  /// [`EventStoreWriteError::ContractViolation`] を返します。新規作成は
+  /// [`EventStore::persist_event_and_snapshot`] を使ってください。
   ///
   /// # 引数
-  /// - `event` - 保存するイベント
-  /// - `version` - イベントを保存する集約のバージョン
+  /// - `event` - 保存するイベント封筒（値渡し — 所有権移動）
+  /// - `expected_version` - 読取済みスナップショット封筒の version（CAS 照合値）
   ///
   /// # 戻り値
   /// - `Ok(())` - 保存に成功した場合
-  /// - `Err(e)` - 保存に失敗した場合
-  async fn persist_event(&mut self, event: &Self::EV, version: usize) -> Result<(), EventStoreWriteError>;
-
-  /// Saves an event and a snapshot.<br/>
-  /// イベント及びスナップショットを保存します。
-  ///
-  /// # 引数
-  /// - `event` - event to be saved / 保存するイベント
-  /// - `aggregate` - aggregate to be saved as a snapshot / スナップショットを保存する集約
-  ///
-  /// # 戻り値
-  /// - `Ok(())` - if succeeded / 保存に成功した場合
-  /// - `Err(e)` - if failed / 保存に失敗した場合
-  async fn persist_event_and_snapshot(
+  /// - `Err(e)` - 保存に失敗した場合（競合時は `OptimisticLockError`）
+  async fn persist_event(
     &mut self,
-    event: &Self::EV,
-    aggregate: &Self::AG,
+    event: EventEnvelope<Self::AID, Self::P>,
+    expected_version: usize,
   ) -> Result<(), EventStoreWriteError>;
 
-  /// 最新のスナップショットを取得する。
-  async fn get_latest_snapshot_by_id(&self, aid: &Self::AID) -> Result<Option<Self::AG>, EventStoreReadError>;
+  /// イベント封筒及びスナップショット（集約状態）を保存します。
+  ///
+  /// BR2.1: seq_nr == 1 は新規作成経路（journal + snapshot の原子的作成、version = 1）、
+  /// seq_nr > 1 は更新経路（version CAS）に分岐します。
+  /// BR2.6: seq_nr == 1 ⇔ expected_version == 0 の対応が崩れる呼び出しは
+  /// [`EventStoreWriteError::ContractViolation`] で拒否します。
+  ///
+  /// # 引数
+  /// - `event` - 保存するイベント封筒（値渡し — 所有権移動）
+  /// - `aggregate` - スナップショットとして保存する集約 payload
+  /// - `expected_version` - 新規作成は 0、更新は読取済みスナップショット封筒の version
+  ///
+  /// # 戻り値
+  /// - `Ok(())` - 保存に成功した場合
+  /// - `Err(e)` - 保存に失敗した場合（競合時は `OptimisticLockError`）
+  async fn persist_event_and_snapshot(
+    &mut self,
+    event: EventEnvelope<Self::AID, Self::P>,
+    aggregate: Self::A,
+    expected_version: usize,
+  ) -> Result<(), EventStoreWriteError>;
 
-  /// 指定したIDとシーケンス番号以降のイベントを取得する。
+  /// 最新のスナップショット封筒を取得する。
+  ///
+  /// BR3.1: 存在しない場合は `None` を返す（エラーにしない）。封筒の seq_nr が
+  /// リプレイ開始点、version が次回書込の expected_version となる（FR2.2）。
+  async fn get_latest_snapshot_by_id(
+    &self,
+    aid: &Self::AID,
+  ) -> Result<Option<SnapshotEnvelope<Self::A>>, EventStoreReadError>;
+
+  /// 指定したIDとシーケンス番号以降のイベント封筒列を取得する。
+  ///
+  /// BR3.2: 裸の payload 列ではなく、列由来メタデータを載せた封筒の列を seq_nr 昇順で返す（FR5.1）。
   async fn get_events_by_id_since_seq_nr(
     &self,
     aid: &Self::AID,
     seq_nr: usize,
-  ) -> Result<Vec<Self::EV>, EventStoreReadError>;
+  ) -> Result<Vec<EventEnvelope<Self::AID, Self::P>>, EventStoreReadError>;
 }
 
 /// 楽観的ロック失敗の説明文字列を整形する。
@@ -116,6 +141,11 @@ pub enum EventStoreWriteError {
   SerializationError(Box<dyn StdError + Send + Sync>),
   #[error("OptimisticLockError: {0}")]
   OptimisticLockError(String),
+  // BR5.2: 契約違反（BR1.4 / BR2.2 / BR2.6 / BR4.1）は専用バリアントで返し、
+  // 他の失敗と型で判別可能にする。理由文字列は規約名 + seq_nr / expected_version の
+  // 数値に限定する（NFR3.2）
+  #[error("ContractViolation: {0}")]
+  ContractViolation(String),
   #[error("IOError: {0}")]
   IOError(#[from] Box<dyn StdError + Send + Sync>),
   #[error("OtherError: {0}")]
@@ -167,5 +197,15 @@ mod tests {
       assert!(allowed_keys.contains(&key), "unexpected field in message: {}", part);
     }
     assert!(!message.contains("://"), "message must not contain connection strings");
+  }
+
+  #[test]
+  fn test_contract_violation_display_carries_reason() {
+    // BR5.2: 契約違反は専用バリアントで判別でき、理由文字列を表示に含める
+    let error = EventStoreWriteError::ContractViolation("BR1.4: seq_nr must be at least 1, seq_nr=0".to_string());
+    assert_eq!(
+      error.to_string(),
+      "ContractViolation: BR1.4: seq_nr must be at least 1, seq_nr=0"
+    );
   }
 }


### PR DESCRIPTION
## 概要

v3（EventEnvelope）の統合ブランチです。5 つの作業単位（Bolt）をマージコミット方式で統合済み:

- **契約コア**: `EventEnvelope` / `SnapshotEnvelope` 新設、`Event` / `Aggregate` trait 廃止（ドメイン型はプレーンな serde 型のみ）、`ContractViolation` 新設、`with_keep_snapshot_count` の Result 化（`Some(0)` 拒否）
- **4 バックエンド封筒化**: Memory / Bigtable（CheckAndMutateRow 原子化 + 保持ポリシー新実装）/ DynamoDB（version 明示値化 + `.unwrap()` 除去）/ SQLite（skey 判別一本化）— 既存負債 4 件解消
- **テスト**: 58 本 green（共有シナリオ 4 バックエンド対称・競合・エラー契約・剪定・不在更新・封筒メタデータ往復）
- **リリース整備**: 移行ガイド（en/ja）・DATABASE_SCHEMA v3 化・CHANGELOG・examples v3 化・README v3 化・clippy 6 構成マトリクス・MSRV 1.94.1 宣言

## ⚠️ マージの帰結

このブランチには `BREAKING CHANGE:` 件名コミット（315dc41）が含まれます。**main へマージすると、次回の日次 cron（または lib-bump-version.yml の手動起動）で major 判定 → v3.0.0 タグ → crates.io への自動 publish が走ります。**

## 補足

- v2 データとの読取互換はありません（移行は利用者責務 — docs/MIGRATION_GUIDE_v3.md 参照）
- MSRV 1.94.1 は AWS SDK スタックの宣言 rust-version 由来（実測）
- DynamoDB テストで testcontainers の PortNotExposed フレークが確率的に出ることがあります（コード起因ではなく再実行で解消）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * イベントとスナップショットをエンベロープで扱う v3 API を追加しました。
  * プレーンな serde 対応データ型を利用できるようになりました。
  * Bigtable のスナップショット履歴保持と原子的な競合検出に対応しました。
  * 契約違反エラーと統一された楽観的ロックエラーを追加しました。

* **破壊的変更**
  * v2 のイベント／集約インターフェースを廃止し、期待バージョンを指定する方式へ変更しました。
  * v2 で保存したデータは v3 で読み取れません。

* **ドキュメント**
  * v3 の変更点、移行手順、データベース仕様、使用例を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->